### PR TITLE
Respect rte allow tags in translate request

### DIFF
--- a/Classes/Client.php
+++ b/Classes/Client.php
@@ -7,6 +7,7 @@ namespace WebVision\WvDeepltranslate;
 use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\WvDeepltranslate\Domain\Dto\TranslateOptions;
 use WebVision\WvDeepltranslate\Exception\ClientNotValidUrlException;
 
 final class Client
@@ -31,15 +32,15 @@ final class Client
         $this->requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
     }
 
-    public function translate(string $content, string $sourceLang, string $targetLang, string $glossary = ''): ResponseInterface
-    {
+    public function translate(
+        string $content,
+        TranslateOptions $options,
+        string $glossary = ''
+    ): ResponseInterface {
         $baseUrl = $this->buildBaseUrl('translate');
 
         $postFields = [
             'text' => $content,
-            'source_lang' => $sourceLang,
-            'target_lang' => $targetLang,
-            'tag_handling' => 'xml',
         ];
 
         if (!empty($glossary)) {
@@ -47,6 +48,8 @@ final class Client
         }
 
         $postFields['formality'] = $this->configuration->getFormality();
+
+        $postFields = array_merge($postFields, $options->toArray());
 
         return $this->requestFactory->request($baseUrl, 'POST', $this->mergeRequiredRequestOptions([
             'form_params' => $postFields,

--- a/Classes/Domain/Dto/TranslateOptions.php
+++ b/Classes/Domain/Dto/TranslateOptions.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Domain\Dto;
+
+/**
+ * @internal
+ */
+final class TranslateOptions
+{
+    protected string $splitSentences = 'nonewlines';
+
+    protected bool $outlineDetection = false;
+
+    protected array $splittingTags = [];
+
+    protected array $nonSplittingTags = [];
+
+    protected array $ignoreTags = [];
+
+    protected string $tagHandling = 'xml';
+
+    protected string $targetLanguage;
+
+    protected string $sourceLanguage;
+
+    public function getSplitSentences(): string
+    {
+        return $this->splitSentences;
+    }
+
+    public function setSplitSentences(string $splitSentences): void
+    {
+        $this->splitSentences = $splitSentences;
+    }
+
+    public function isOutlineDetection(): bool
+    {
+        return $this->outlineDetection;
+    }
+
+    public function setOutlineDetection(bool $outlineDetection): void
+    {
+        $this->outlineDetection = $outlineDetection;
+    }
+
+    public function getSplittingTags(): array
+    {
+        return $this->splittingTags;
+    }
+
+    public function setSplittingTags(array $splittingTags): void
+    {
+        $this->splittingTags = $splittingTags;
+    }
+
+    public function getNonSplittingTags(): array
+    {
+        return $this->nonSplittingTags;
+    }
+
+    public function setNonSplittingTags(array $nonSplittingTags): void
+    {
+        $this->nonSplittingTags = $nonSplittingTags;
+    }
+
+    public function getIgnoreTags(): array
+    {
+        return $this->ignoreTags;
+    }
+
+    public function setIgnoreTags(array $ignoreTags): void
+    {
+        $this->ignoreTags = $ignoreTags;
+    }
+
+    public function getTagHandling(): string
+    {
+        return $this->tagHandling;
+    }
+
+    public function setTagHandling(string $tagHandling): void
+    {
+        $this->tagHandling = $tagHandling;
+    }
+
+    public function getTargetLanguage(): string
+    {
+        return $this->targetLanguage;
+    }
+
+    public function setTargetLanguage(string $targetLanguage): void
+    {
+        $this->targetLanguage = $targetLanguage;
+    }
+
+    public function getSourceLanguage(): string
+    {
+        return $this->sourceLanguage;
+    }
+
+    public function setSourceLanguage(string $sourceLanguage): void
+    {
+        $this->sourceLanguage = $sourceLanguage;
+    }
+
+    public function toArray(): array
+    {
+        $param = [];
+        $param['tag_handling'] = $this->tagHandling;
+
+        if (!empty($this->splittingTags)) {
+            $param['outlineDetection'] = $this->outlineDetection;
+            $param['split_sentences'] = $this->splitSentences;
+            $param['splitting_tags'] = implode(',', $this->splittingTags);
+        }
+
+        $param['source_lang'] = $this->sourceLanguage;
+        $param['target_lang'] = $this->targetLanguage;
+
+        return $param;
+    }
+}

--- a/Classes/Resolver/RichtextAllowTagsResolver.php
+++ b/Classes/Resolver/RichtextAllowTagsResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Resolver;
+
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Configuration\Richtext;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class RichtextAllowTagsResolver
+{
+    private Richtext $richtext;
+
+    public function __construct(
+        ?Richtext $richtext = null
+    ) {
+        $this->richtext = $richtext ?? GeneralUtility::makeInstance(Richtext::class);
+    }
+
+    public function resolve(string $tableName, int $recordId, string $fieldName): array
+    {
+        if (!isset($GLOBALS['TCA'][$tableName]['columns'])) {
+            throw new \RuntimeException('TCA Columns ist not defined', 1689950520561);
+        }
+
+        $field = $GLOBALS['TCA'][$tableName]['columns'][$fieldName];
+
+        if (!isset($field['config']['type'])) {
+            return [];
+        }
+
+        if ($field['config']['type'] !== 'text') {
+            return [];
+        }
+
+        if (isset($field['config']['enableRichtext'])) {
+            if ($field['config']['enableRichtext'] === false) {
+                return [];
+            }
+        } elseif (isset($GLOBALS['TCA'][$tableName]['types']['columnsOverrides'][$fieldName]['config']['enableRichtext'])) {
+            if ($GLOBALS['TCA'][$tableName]['types']['columnsOverrides'][$fieldName]['config']['enableRichtext'] === false) {
+                return [];
+            }
+        }
+
+        $record = BackendUtility::getRecord($tableName, $recordId);
+
+        $allowTags = [];
+        $rteConfig = $this->richtext->getConfiguration($tableName, $fieldName, $record['pid'], $record['CType'], $field['config']);
+        if (isset($rteConfig['processing']['allowTags'])) {
+            $allowTags = array_unique(array_merge($allowTags, $rteConfig['processing']['allowTags']), SORT_REGULAR);
+        }
+
+        return $allowTags;
+    }
+}

--- a/Classes/Service/DeeplService.php
+++ b/Classes/Service/DeeplService.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 use WebVision\WvDeepltranslate\Client;
+use WebVision\WvDeepltranslate\Domain\Dto\TranslateOptions;
 use WebVision\WvDeepltranslate\Domain\Repository\GlossaryRepository;
 use WebVision\WvDeepltranslate\Domain\Repository\SettingsRepository;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
@@ -63,26 +64,27 @@ class DeeplService
      * Deepl Api Call for retrieving translation.
      * @return array<int|string, mixed>
      */
-    public function translateRequest(string $content, string $targetLanguage, string $sourceLanguage): array
+    public function translateRequest(string $content, TranslateOptions $translateOptions): array
     {
         // If the source language is set to Autodetect, no glossary can be detected.
-        if ($sourceLanguage === 'auto') {
-            $sourceLanguage = '';
+        if ($translateOptions->getSourceLanguage() === 'auto') {
+            $translateOptions->setSourceLanguage('');
             $glossary['glossary_id'] = '';
         } else {
             // TODO make glossary findable by current site
             $glossary = $this->glossaryRepository->getGlossaryBySourceAndTarget(
-                $sourceLanguage,
-                $targetLanguage,
+                $translateOptions->getSourceLanguage(),
+                $translateOptions->getSourceLanguage(),
                 DeeplBackendUtility::detectCurrentPage()
             );
         }
 
         try {
-            if(!isset($glossary['glossary_id'])) {
+            if (!isset($glossary['glossary_id'])) {
                 $glossary['glossary_id'] = '';
             }
-            $response = $this->client->translate($content, $sourceLanguage, $targetLanguage, $glossary['glossary_id']);
+
+            $response = $this->client->translate($content, $translateOptions, $glossary['glossary_id']);
         } catch (ClientException $e) {
             $flashMessage = GeneralUtility::makeInstance(
                 FlashMessage::class,

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -121,8 +121,8 @@ class DeeplBackendUtility
         self::$apiKey = $extensionConfiguration['apiKey'];
         self::$deeplFormality = $extensionConfiguration['deeplFormality'];
         self::$apiUrl = $extensionConfiguration['apiUrl'];
-        self::$googleApiUrl = $extensionConfiguration['googleapiUrl'];
-        self::$googleApiKey = $extensionConfiguration['googleapiKey'];
+        self::$googleApiUrl = $extensionConfiguration['googleapiUrl'] ?? '';
+        self::$googleApiKey = $extensionConfiguration['googleapiKey'] ?? '';
 
         self::$configurationLoaded = true;
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -30,6 +30,10 @@ services:
     arguments:
       $cache: '@cache.wvdeepltranslate'
 
+  WebVision\WvDeepltranslate\Resolver\RichtextAllowTagsResolver:
+    arguments:
+      $richtext: '@TYPO3\CMS\Core\Configuration\Richtext'
+
   cache.wvdeepltranslate:
     class: TYPO3\CMS\Core\Cache\Frontend\FrontendInterface
     factory: [ '@TYPO3\CMS\Core\Cache\CacheManager', 'getCache' ]

--- a/Tests/Functional/ClientTest.php
+++ b/Tests/Functional/ClientTest.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\WvDeepltranslate\Client;
 use WebVision\WvDeepltranslate\Configuration;
+use WebVision\WvDeepltranslate\Domain\Dto\TranslateOptions;
 
 /**
  * @covers \WebVision\WvDeepltranslate\Client
@@ -49,12 +50,15 @@ class ClientTest extends FunctionalTestCase
         if (defined('DEEPL_MOCKSERVER_USED') && DEEPL_MOCKSERVER_USED === true) {
             $translateContent = 'proton beam';
         }
+
+        $translateOptions = new TranslateOptions();
+        $translateOptions->setSourceLanguage('EN');
+        $translateOptions->setTargetLanguage('DE');
+
         $client = new Client();
         $response = $client->translate(
             $translateContent,
-            'EN',
-            'DE',
-            ''
+            $translateOptions,
         );
 
         static::assertSame(200, $response->getStatusCode());
@@ -68,17 +72,20 @@ class ClientTest extends FunctionalTestCase
     public function checkJsonTranslateContentIsValid(): void
     {
         $translateContent = 'I would like to be translated!';
-        $expectedTranslation = 'Ich möchte gern übersetzt werden!';
+        $expectedTranslation = 'Ich möchte gerne übersetzt werden!';
         if (defined('DEEPL_MOCKSERVER_USED') && DEEPL_MOCKSERVER_USED === true) {
             $translateContent = 'proton beam';
             $expectedTranslation = 'Protonenstrahl';
         }
+
+        $translateOptions = new TranslateOptions();
+        $translateOptions->setSourceLanguage('EN');
+        $translateOptions->setTargetLanguage('DE');
+
         $client = new Client();
         $response = $client->translate(
             $translateContent,
-            'EN',
-            'DE',
-            ''
+            $translateOptions,
         );
 
         $content = $response->getBody()->getContents();

--- a/Tests/Functional/Hooks/TranslateHookTest.php
+++ b/Tests/Functional/Hooks/TranslateHookTest.php
@@ -8,6 +8,7 @@ use Nimut\TestingFramework\TestCase\FunctionalTestCase;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\WvDeepltranslate\Domain\Dto\TranslateOptions;
 use WebVision\WvDeepltranslate\Hooks\TranslateHook;
 use WebVision\WvDeepltranslate\Service\LanguageService;
 
@@ -61,14 +62,15 @@ class TranslateHookTest extends FunctionalTestCase
         $languageService = GeneralUtility::makeInstance(LanguageService::class);
         $siteConfig = $languageService->getCurrentSite('pages', 1);
         $sourceLanguageRecord = $languageService->getSourceLanguage($siteConfig['site']);
+
+        $translateOptions = new TranslateOptions();
+        $translateOptions->setSourceLanguage($sourceLanguageRecord['language_isocode']);
+        $translateOptions->setTargetLanguage('DE');
+
         $content = $translateHook->translateContent(
             $translateContent,
-            [
-                'uid' => 2,
-                'language_isocode' => 'DE',
-            ],
+            $translateOptions,
             'deepl',
-            $sourceLanguageRecord
         );
 
         static::assertSame($expectedTranslation, $content);
@@ -86,15 +88,15 @@ class TranslateHookTest extends FunctionalTestCase
         $languageService = GeneralUtility::makeInstance(LanguageService::class);
         $siteConfig = $languageService->getCurrentSite('pages', 1);
         $sourceLanguageRecord = $languageService->getSourceLanguage($siteConfig['site']);
+
+        $translateOptions = new TranslateOptions();
+        $translateOptions->setSourceLanguage($sourceLanguageRecord['language_isocode']);
+        $translateOptions->setTargetLanguage('BS');
+
         $content = $translateHook->translateContent(
             'Hello I would like to be translated',
-            [
-                'uid' => 3, // This ist the LanguageID its was Configure in SiteConfig
-                'title' => 'not supported language',
-                'language_isocode' => 'BS',
-            ],
+            $translateOptions,
             'deepl',
-            $sourceLanguageRecord
         );
 
         static::assertSame('Hello I would like to be translated', $content);

--- a/Tests/Functional/Resolver/Fixtures/Pages.xml
+++ b/Tests/Functional/Resolver/Fixtures/Pages.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <pages>
+        <uid>1</uid>
+        <pid>0</pid>
+        <title>DeepL-Functional-Tests</title>
+        <doktype>1</doktype>
+        <is_siteroot>1</is_siteroot>
+    </pages>
+    <pages>
+        <uid>3</uid>
+        <pid>0</pid>
+        <title>DeepL-Functional-Tests BS</title>
+        <doktype>1</doktype>
+        <is_siteroot>1</is_siteroot>
+    </pages>
+    <tt_content>
+        <uid>1</uid>
+        <pid>1</pid>
+        <header>DeepL-Functional-Test Element</header>
+        <CType>text</CType>
+        <bodytext></bodytext>
+    </tt_content>
+</dataset>

--- a/Tests/Functional/Resolver/RichtextAllowTagsResolverTest.php
+++ b/Tests/Functional/Resolver/RichtextAllowTagsResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Functional\Resolver;
+
+use Nimut\TestingFramework\TestCase\FunctionalTestCase;
+use TYPO3\CMS\Core\Configuration\Loader\YamlFileLoader;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\WvDeepltranslate\Resolver\RichtextAllowTagsResolver;
+
+class RichtextAllowTagsResolverTest extends FunctionalTestCase
+{
+    /**
+     * @var string[]
+     */
+    protected $testExtensionsToLoad = [
+        'typo3conf/ext/wv_deepltranslate',
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected $coreExtensionsToLoad = [
+        'rte_ckeditor',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importDataSet(__DIR__ . '/Fixtures/Pages.xml');
+    }
+
+    /**
+     * @test
+     */
+    public function findRteConfigurationAllowTagsByRecords(): void
+    {
+        $richtextAllowTagsResolver = GeneralUtility::makeInstance(RichtextAllowTagsResolver::class);
+        $allowTags = $richtextAllowTagsResolver->resolve('tt_content', 1, 'bodytext');
+
+        static::assertTrue((bool)array_search('em', $allowTags));
+
+        $yamlLoader = GeneralUtility::makeInstance(YamlFileLoader::class);
+        $config = $yamlLoader->load('EXT:rte_ckeditor/Configuration/RTE/Processing.yaml');
+
+        static::assertSame($config['processing']['allowTags'], $allowTags);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
 		"typo3/cms-frontend": "^9.5 || ^10.4 || ^11.5",
 		"typo3/cms-info": "^9.5 || ^10.4 || ^11.5",
 		"typo3/cms-lowlevel": "^9.5 || ^10.4 || ^11.5",
+		"typo3/cms-rte-ckeditor": "^9.5 || ^10.4 || ^11.5",
 		"typo3/cms-tstemplate": "^9.5 || ^10.4 || ^11.5",
 		"typo3/cms-workspaces": "^9.5 || ^10.4 || ^11.5",
 		"typo3/coding-standards": "^0.5"


### PR DESCRIPTION
With this change the RTE configuration is determined from the field to be translated. To give deepl a list of allowed HTML tags.
To allow a correct separation in the translated text with HTML tag.

Resolve #278