### PR TITLE
[FEATURE] Add command to import glossary entries

### DIFF
--- a/Classes/Command/GlossaryCsvImportCommand.php
+++ b/Classes/Command/GlossaryCsvImportCommand.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+use TYPO3\CMS\Backend\Configuration\TranslationConfigurationProvider;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\WvDeepltranslate\Service\ImportGlossaryEntryService;
+
+class GlossaryCsvImportCommand extends Command
+{
+    use GlossaryCommandTrait;
+
+    protected ImportGlossaryEntryService  $importGlossaryEntryService;
+
+    public function __construct(ImportGlossaryEntryService $importGlossaryEntryService, ?string $name = null)
+    {
+        $this->importGlossaryEntryService = $importGlossaryEntryService;
+        parent::__construct($name);
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        Bootstrap::initializeBackendAuthentication();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+                'pageId',
+                'p',
+                InputOption::VALUE_REQUIRED,
+                'Page to import to',
+                null
+            )
+            ->addOption(
+                'csvFilePath',
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'The path to the csv file',
+                null
+            )
+            ->addOption(
+                'csvSeparator',
+                's',
+                InputOption::VALUE_OPTIONAL,
+                'csv seperator default: ,',
+                ','
+            )
+            ->addOption(
+                'targetSysLanguage',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'The target language sys_language_uid',
+                null
+            );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Glossary Entry CSV Import');
+
+        $pageId = (int) $input->getOption('pageId');
+        $sysLanguageUid = (int) $input->getOption('targetSysLanguage');
+
+        if ($this->translationExistsForPage($pageId, $sysLanguageUid) === false) {
+            $io->error(
+                'Page with uid: "' . $pageId . '" has no translation for sys_language_uid: "' . $sysLanguageUid .
+                '". Create a translation for this page first'
+            );
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $glossaryEntries = $this->importGlossaryEntryService->getGlossaryEntriesFromCsv(
+                (string) $input->getOption('csvFilePath'),
+                (string) $input->getOption('csvSeparator'),
+                $pageId
+            );
+
+            $this->importGlossaryEntryService->insertEntriesLocal($glossaryEntries, $pageId, $sysLanguageUid);
+            $this->outputFailures($io);
+
+            $this->deeplGlossaryService->syncGlossaries($pageId);
+        } catch (Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    protected function outputFailures(SymfonyStyle $symfonyStyle): void
+    {
+        $allEntriesCount = count($this->importGlossaryEntryService->getAllEntries());
+        $successCount = $allEntriesCount - $this->importGlossaryEntryService->getFailuresCount();
+
+        foreach ($this->importGlossaryEntryService->getDataHandlerErrors() as $dataHandlerError) {
+            $symfonyStyle->error('Error while inserting data:' . $dataHandlerError);
+        }
+
+        foreach (
+            $this->importGlossaryEntryService->getFailedEntries(ImportGlossaryEntryService::ERROR_INVALID)
+            as $csvColumn => $entry
+        ) {
+            $symfonyStyle->error('Invalid csv entry ' . $entry . 'in line: ' . $csvColumn);
+        }
+
+        foreach (
+            $this->importGlossaryEntryService->getFailedEntries(ImportGlossaryEntryService::ERROR_EXISTING)
+            as $column => $entry
+        ) {
+            $symfonyStyle->info('Skipping entry ' . $entry . ' as it already exists. Line: ' . $column);
+        }
+
+        foreach (
+            $this->importGlossaryEntryService->getFailedEntries(ImportGlossaryEntryService::ERROR_LOCALIZATION)
+            as $entry
+        ) {
+            $symfonyStyle->error('Failed to localize entry: ' . $entry);
+        }
+
+        $symfonyStyle->info('Imported ' . $successCount . '/' . $allEntriesCount . ' entries.');
+    }
+
+    protected function translationExistsForPage(int $pageId, int $sysLanguageId): bool
+    {
+        $translations = GeneralUtility::makeInstance(TranslationConfigurationProvider::class)
+            ->translationInfo('pages', $pageId);
+
+        if (is_array($translations) === false) {
+            return false;
+        }
+
+        foreach ($translations['translations'] as $translation) {
+            if ((int)($translation['sys_language_uid'] ?? 0) === $sysLanguageId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Classes/Domain/Repository/GlossaryEntryRepository.php
+++ b/Classes/Domain/Repository/GlossaryEntryRepository.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace WebVision\WvDeepltranslate\Domain\Repository;
 
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 // @todo Consider to rename/move this as service class.
 final class GlossaryEntryRepository
 {
+    protected Connection $connection;
+
+    public function __construct(ConnectionPool $connectionPool)
+    {
+        $this->connection = $connectionPool->getConnectionForTable('tx_wvdeepltranslate_glossaryentry');
+    }
+
     /**
      * @deprecated
      */
@@ -25,10 +32,7 @@ final class GlossaryEntryRepository
      */
     public function findEntriesByGlossary(int $parentId): array
     {
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_wvdeepltranslate_glossaryentry');
-
-        $result = $connection->select(
+        $result = $this->connection->select(
             ['*'],
             'tx_wvdeepltranslate_glossaryentry',
             [
@@ -44,10 +48,7 @@ final class GlossaryEntryRepository
      */
     public function findEntryByUid(int $uid): array
     {
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable('tx_wvdeepltranslate_glossaryentry');
-
-        $result = $connection->select(
+        $result = $this->connection->select(
             ['*'],
             'tx_wvdeepltranslate_glossaryentry',
             [
@@ -57,5 +58,16 @@ final class GlossaryEntryRepository
 
         // @todo Should we not better returning null instead of an empty array if nor recourd could be retrieved ?
         return $result->fetchAssociative() ?: [];
+    }
+
+    public function findBy(array $identifiers): ?array
+    {
+        $result = $this->connection->select(
+            ['*'],
+            'tx_wvdeepltranslate_glossaryentry',
+            $identifiers
+        )->fetchAssociative();
+
+        return is_array($result) ? $result : null;
     }
 }

--- a/Classes/Exception/FileNotFoundException.php
+++ b/Classes/Exception/FileNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Exception;
+
+use Exception;
+
+class FileNotFoundException extends Exception
+{
+}

--- a/Classes/Service/ImportGlossaryEntryService.php
+++ b/Classes/Service/ImportGlossaryEntryService.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Service;
+
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Type\Bitmask\Permission;
+use TYPO3\CMS\Core\Utility\CsvUtility;
+use WebVision\WvDeepltranslate\Domain\Repository\GlossaryEntryRepository;
+use WebVision\WvDeepltranslate\Exception\FileNotFoundException;
+
+final class ImportGlossaryEntryService
+{
+    public const ERROR_INVALID = 'invalid';
+    public const ERROR_EXISTING = 'existing';
+    public const ERROR_LOCALIZATION = 'localization';
+
+    protected ResourceFactory $resourceFactory;
+    protected GlossaryEntryRepository $glossaryEntryRepository;
+    protected DataHandler $dataHandler;
+
+    protected array $allEntries = [];
+    protected array $failedEntries = [
+        self::ERROR_INVALID => [],
+        self::ERROR_EXISTING => [],
+        self::ERROR_LOCALIZATION => [],
+    ];
+
+    public function __construct(
+        ResourceFactory $resourceFactory,
+        GlossaryEntryRepository $glossaryEntryRepository,
+        DataHandler $dataHandler
+    ) {
+        $this->resourceFactory = $resourceFactory;
+        $this->glossaryEntryRepository = $glossaryEntryRepository;
+        $this->dataHandler = $dataHandler;
+    }
+
+    /**
+     * @throws FileNotFoundException
+     * @return array<mixed>
+     */
+    public function getGlossaryEntriesFromCsv(string $filePath, string $separator, int $pageId): array
+    {
+        $fileContent = $this->getFileContents($filePath);
+
+        if ($fileContent === null) {
+            throw new FileNotFoundException('Csv file not found identifier: ' . $filePath, 1729245627);
+        }
+
+        $this->allEntries = CsvUtility::csvToArray($fileContent, $separator, '"', 2);
+
+        return $this->getValidatedEntries($pageId);
+    }
+
+    /**
+     * @param int $pageId
+     * @return array<mixed>
+     */
+    protected function getValidatedEntries(int $pageId): array
+    {
+        $entries = [];
+
+        foreach ($this->allEntries as $index => $entry) {
+            $csvColumn = $index + 1;
+            $originalEntry = (string)($entry[0] ?? '');
+            $localizedEntry = (string)($entry[1] ?? '');
+
+            if (count($entry) !== 2 || $originalEntry === '' || $localizedEntry === '') {
+                $this->failedEntries['invalid'][$csvColumn] = $originalEntry;
+                continue;
+            }
+
+            if (
+                $this->entryExists($originalEntry, $pageId) === true ||
+                $this->entryExists($localizedEntry, $pageId) === true
+            ) {
+                $this->failedEntries['existing'][$csvColumn] = $originalEntry;
+                continue;
+            }
+
+            $entries[] = $entry;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param array<mixed> $entries
+     * @param int $pageId
+     * @param int $sysLanguageUid
+     * @return void
+     */
+    public function insertEntriesLocal(array $entries, int $pageId, int $sysLanguageUid): void
+    {
+        $mappedEntries = $this->insertOriginalEntries($entries, $pageId);
+        $this->insertLocalizedEntries($mappedEntries, $pageId, $sysLanguageUid);
+    }
+
+    /**
+     * @param array<mixed> $entries
+     * @param int $pageId
+     * @return array<mixed>
+     */
+    protected function insertOriginalEntries(array $entries, int $pageId): array
+    {
+        $mappedEntries = [];
+        $data = [
+            'tx_wvdeepltranslate_glossaryentry' => [],
+        ];
+
+        foreach ($entries as $index => $entry) {
+            $originalNewId = 'NEW_original_' . $index;
+            $originalEntry = (string)($entry[0] ?? '');
+            $mappedEntries[$originalNewId] = $entry;
+
+            $data['tx_wvdeepltranslate_glossaryentry'][$originalNewId] = [
+                'pid' => $pageId,
+                'term' => $originalEntry,
+            ];
+        }
+
+        $this->dataHandler->start($data, []);
+        $this->dataHandler->process_datamap();
+
+        return $mappedEntries;
+    }
+
+    /**
+     * @param array<mixed> $mappedEntries
+     * @param int $pageId
+     * @param int $sysLanguageUid
+     * @return void
+     */
+    protected function insertLocalizedEntries(array $mappedEntries, int $pageId, int $sysLanguageUid): void
+    {
+        $localizedData = [
+            'tx_wvdeepltranslate_glossaryentry' => [],
+        ];
+
+        foreach ($mappedEntries as $identifier => $entry) {
+            $uid = (int) ($this->dataHandler->substNEWwithIDs[$identifier] ?? 0);
+            $originalEntry = (string)($entry[0] ?? '');
+            $localizedEntry = (string)($entry[1] ?? '');
+
+            if (
+                $uid === 0 ||
+                $this->dataHandler->doesRecordExist(
+                    'tx_wvdeepltranslate_glossaryentry',
+                    $uid,
+                    Permission::ALL
+                ) === false
+            ) {
+                $this->failedEntries['localization'][] = $originalEntry;
+                continue;
+            }
+
+            $localizedData['tx_wvdeepltranslate_glossaryentry'][$identifier . '_localized'] = [
+                'l10n_parent' => $uid,
+                'sys_language_uid' => $sysLanguageUid,
+                'pid' => $pageId,
+                'term' => $localizedEntry,
+            ];
+        }
+
+        $this->dataHandler->start($localizedData, []);
+        $this->dataHandler->process_datamap();
+    }
+
+    public function entryExists(string $term, int $pageId): bool
+    {
+        return $this->glossaryEntryRepository->findBy(['pid' => $pageId, 'term' => $term]) !== null;
+    }
+
+    protected function getFileContents(string $csvFilePath): ?string
+    {
+        if (file_exists($csvFilePath)) {
+            $fileContents = file_get_contents($csvFilePath, true);
+            return $fileContents !== false ? $fileContents : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function getAllEntries(): array
+    {
+        return $this->allEntries;
+    }
+
+    /**
+     * @param string $key
+     * @return array<string>
+     */
+    public function getFailedEntries(string $key): array
+    {
+        return $this->failedEntries[$key] ?? [];
+    }
+
+    public function getFailuresCount(): int
+    {
+        return count($this->failedEntries[self::ERROR_INVALID]) +
+            count($this->failedEntries[self::ERROR_EXISTING]) +
+            count($this->failedEntries[self::ERROR_LOCALIZATION]);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getDataHandlerErrors(): array
+    {
+        return $this->dataHandler->errorLog;
+    }
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -14,6 +14,7 @@ use TYPO3\CMS\Dashboard\WidgetRegistry;
 use WebVision\WvDeepltranslate\Client;
 use WebVision\WvDeepltranslate\ClientInterface;
 use WebVision\WvDeepltranslate\Command\GlossaryCleanupCommand;
+use WebVision\WvDeepltranslate\Command\GlossaryCsvImportCommand;
 use WebVision\WvDeepltranslate\Command\GlossaryListCommand;
 use WebVision\WvDeepltranslate\Command\GlossarySyncCommand;
 use WebVision\WvDeepltranslate\Controller\Backend\AjaxController;
@@ -75,6 +76,16 @@ return function (ContainerConfigurator $containerConfigurator, ContainerBuilder 
                 'command' => 'deepl:glossary:list',
                 'description' => 'List Glossary entries or entries by glossary_id',
                 'schedulable' => false,
+            ]
+        );
+    $services
+        ->set(GlossaryCsvImportCommand::class)
+        ->tag(
+            'console.command',
+            [
+                'command' => 'deepl:glossary:import',
+                'description' => 'Import glossary entries from a csv file',
+                'schedulable' => true,
             ]
         );
 

--- a/Documentation/Housekeeping/Index.rst
+++ b/Documentation/Housekeeping/Index.rst
@@ -61,4 +61,27 @@ CLI command).
 
 Accepts pageId as option. If not given, syncs all available glossaries.
 
+Import
+-------
+
+It is possible to import glossary entries from a csv file.
+
+..  code-block:: bash
+
+    vendor/bin/typo3 deepl:glossary:import --pageId 123 --csvFilePath ./import.csv --csvSeparator \; --targetSysLanguage 1
+
+pageId of the page where the records are imported to.
+The csvFilePath configures which file should be used for importing.
+The csvSeparator option declares the seperator used in the csv file.
+The targetSysLanguage defines the translated language. The TYPO3 sys_language_uid must be provided.
+
+The format of csv file must be two columns per row.
+The left column is the original (source) language and the right column is the localization (target) language.
+
+Example csv file:
+..  code-block:: bash
+    "english Label";"englische Übersetzung"
+    "another Label";"eine andere Übersetzung"
+    "console command";"Konsolenbefehl"
+
 ..  _typo3_console: https://extensions.typo3.org/extension/typo3_console

--- a/Tests/Functional/Fixtures/entries.csv
+++ b/Tests/Functional/Fixtures/entries.csv
@@ -1,0 +1,7 @@
+tx_wvdeepltranslate_glossaryentry,,,,,
+,"uid","pid","l10n_parent","sys_language_uid","term"
+,1,1,0,0,"test one"
+,2,1,1,1,"test eins"
+,3,1,0,0,"test two"
+,4,1,3,1,"test zwei"
+

--- a/Tests/Functional/Fixtures/importEntries.csv
+++ b/Tests/Functional/Fixtures/importEntries.csv
@@ -1,0 +1,3 @@
+"test one","test eins"
+"test two","test zwei"
+"test three","test drei"

--- a/Tests/Functional/Services/ImportGlossaryEntryServiceTest.php
+++ b/Tests/Functional/Services/ImportGlossaryEntryServiceTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvDeepltranslate\Tests\Functional\Services;
+
+use WebVision\WvDeepltranslate\Exception\FileNotFoundException;
+use WebVision\WvDeepltranslate\Service\ImportGlossaryEntryService;
+use WebVision\WvDeepltranslate\Tests\Functional\AbstractDeepLTestCase;
+
+final class ImportGlossaryEntryServiceTest extends AbstractDeepLTestCase
+{
+    protected function setUp(): void
+    {
+        $this->configurationToUseInTestInstance = array_merge(
+            $this->configurationToUseInTestInstance,
+            require __DIR__ . '/../Fixtures/ExtensionConfig.php'
+        );
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/pages.csv');
+
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function getGlossaryEntriesFromCsvFileNotExists(): void
+    {
+        /** @var ImportGlossaryEntryService $importService */
+        $importService = $this->get(ImportGlossaryEntryService::class);
+        $importService->getGlossaryEntriesFromCsv('nonExisting.csv', ';', 1);
+
+        static::expectException(FileNotFoundException::class);
+        static::assertCount(0, $importService->getAllEntries());
+    }
+
+    /**
+     * @test
+     */
+    public function getGlossaryEntriesFromCsv(): void
+    {
+        /** @var ImportGlossaryEntryService $importService */
+        $importService = $this->get(ImportGlossaryEntryService::class);
+
+        $entries = $importService->getGlossaryEntriesFromCsv(__DIR__ . '/../Fixtures/importEntries.csv', ',', 1);
+
+        self::assertSame(
+            [
+                ['test one', 'test eins'],
+                ['test two', 'test zwei'],
+                ['test three', 'test drei'],
+            ],
+            $entries
+        );
+        static::assertCount(3, $importService->getAllEntries());
+    }
+
+    /**
+     * @test
+     */
+    public function getGlossaryEntriesFromCsvAlreadyExists(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/entries.csv');
+
+        /** @var ImportGlossaryEntryService $importService */
+        $importService = $this->get(ImportGlossaryEntryService::class);
+        $entries = $importService->getGlossaryEntriesFromCsv(__DIR__ . '/../Fixtures/importEntries.csv', ',', 1);
+
+        self::assertSame([['test three', 'test drei']], $entries);
+        static::assertCount(
+            2,
+            $importService->getFailedEntries(ImportGlossaryEntryService::ERROR_EXISTING)
+        );
+    }
+}


### PR DESCRIPTION
A common use case is to import glossary entries from a csv file. This command provides the feature to import glossary entries from a csv file, uploaded to the TYPO3 filelist. The entries are first imported to TYPO3 and then to deepl.