### PR TITLE
[BUGFIX] Fix regression on editor setup needed

### DIFF
--- a/Classes/Event/Listener/GlossarySyncButtonProvider.php
+++ b/Classes/Event/Listener/GlossarySyncButtonProvider.php
@@ -11,6 +11,7 @@ use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\Components\ModifyButtonBarEvent;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -59,7 +60,10 @@ final class GlossarySyncButtonProvider
             return;
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)
+        ) {
             return;
         }
 

--- a/Classes/Hooks/ButtonBarHook.php
+++ b/Classes/Hooks/ButtonBarHook.php
@@ -9,6 +9,7 @@ use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -49,7 +50,10 @@ class ButtonBarHook
             return $buttons;
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)
+        ) {
             return $buttons;
         }
 

--- a/Classes/Override/Core11/DatabaseRecordList.php
+++ b/Classes/Override/Core11/DatabaseRecordList.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace WebVision\WvDeepltranslate\Override\Core11;
 
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\Features;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\WvDeepltranslate\Access\AllowedTranslateAccess;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
@@ -34,7 +36,10 @@ class DatabaseRecordList extends \TYPO3\CMS\Recordlist\RecordList\DatabaseRecord
             return $out;
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)
+        ) {
             return $out;
         }
 

--- a/Classes/Override/Core11/DeeplRecordListController.php
+++ b/Classes/Override/Core11/DeeplRecordListController.php
@@ -7,6 +7,7 @@ namespace WebVision\WvDeepltranslate\Override\Core11;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Exception;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
@@ -42,7 +43,10 @@ final class DeeplRecordListController extends RecordListController
             return $originalOutput;
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)
+        ) {
             return $originalOutput;
         }
 
@@ -81,7 +85,10 @@ final class DeeplRecordListController extends RecordListController
             return '';
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)
+        ) {
             return '';
         }
 

--- a/Classes/Override/Core12/DatabaseRecordList.php
+++ b/Classes/Override/Core12/DatabaseRecordList.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace WebVision\WvDeepltranslate\Override\Core12;
 
+use TYPO3\CMS\Core\Configuration\Features;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\WvDeepltranslate\Access\AllowedTranslateAccess;
 use WebVision\WvDeepltranslate\Utility\DeeplBackendUtility;
 
@@ -33,7 +35,10 @@ class DatabaseRecordList extends \TYPO3\CMS\Backend\RecordList\DatabaseRecordLis
             return $out;
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)
+        ) {
             return $out;
         }
 

--- a/Classes/Override/Core12/DeeplRecordListController.php
+++ b/Classes/Override/Core12/DeeplRecordListController.php
@@ -7,6 +7,7 @@ namespace WebVision\WvDeepltranslate\Override\Core12;
 use Doctrine\DBAL\Driver\Exception;
 use TYPO3\CMS\Backend\Controller\RecordListController;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+use TYPO3\CMS\Core\Configuration\Features;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
@@ -46,7 +47,10 @@ final class DeeplRecordListController extends RecordListController
             return $originalOutput;
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)
+        ) {
             return $originalOutput;
         }
 
@@ -84,7 +88,10 @@ final class DeeplRecordListController extends RecordListController
             return '';
         }
 
-        if (!$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)) {
+        if (
+            GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+            && !$this->getBackendUserAuthentication()->check('custom_options', AllowedGlossarySyncAccess::ALLOWED_GLOSSARY_SYNC)
+        ) {
             return '';
         }
 

--- a/Classes/ViewHelpers/Be/Access/DeeplTranslateAllowedViewHelper.php
+++ b/Classes/ViewHelpers/Be/Access/DeeplTranslateAllowedViewHelper.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace WebVision\WvDeepltranslate\ViewHelpers\Be\Access;
 
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Configuration\Features;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 use WebVision\WvDeepltranslate\Access\AllowedTranslateAccess;
@@ -18,7 +20,10 @@ final class DeeplTranslateAllowedViewHelper extends AbstractConditionViewHelper
 
     public static function verdict(array $arguments, RenderingContextInterface $renderingContext): bool
     {
-        if (self::getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)) {
+        if (
+            !GeneralUtility::makeInstance(Features::class)->isFeatureEnabled('deeplTranslationUserConfigured')
+             || self::getBackendUserAuthentication()->check('custom_options', AllowedTranslateAccess::ALLOWED_TRANSLATE_OPTION_VALUE)
+        ) {
             return true;
         }
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -95,6 +95,8 @@ defined('TYPO3') or die();
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['wvdeepltranslate']['backend']
         ??= \TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend::class;
 
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['deeplTranslationUserConfigured'] ??= false;
+
     $accessRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\WebVision\WvDeepltranslate\Access\AccessRegistry::class);
     $accessRegistry->addAccess((new \WebVision\WvDeepltranslate\Access\AllowedTranslateAccess()));
     $accessRegistry->addAccess((new \WebVision\WvDeepltranslate\Access\AllowedGlossarySyncAccess()));


### PR DESCRIPTION
The PR #361 added the feature setting restirctions to backend users and groups. This feature introduced accidentally a breaking change setting the user and group permissions required.

With this commit, a feature is added allowing set up of translation restrictions after enabling the feature in LocalConfiguration.

Changed behaviour:

* Added feature toggle `deeplTranslationUserConfigured`

If you want to use this new feature, enable
`$GLOBALS['TYPO3_CONF_VARS']['SYS']['features']['deeplTranslationUserConfigured']` in your `LocalConfiguration` or `config/system/settings.php`.

Fixes #379 