### PR TITLE
[TASK] Ensure failing `php-cs-fixer` within Github Action pipeline

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -53,7 +53,7 @@ jobs:
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure tests methods do not start with \"test\""
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"

--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Tests\Functional;
 
-use RuntimeException;
 use Closure;
-use Exception;
 use DeepL\Translator;
 use DeepL\TranslatorOptions;
+use Exception;
 use phpmock\phpunit\PHPMock;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Core\Utility\StringUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;

--- a/Tests/Functional/ClientTest.php
+++ b/Tests/Functional/ClientTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Tests\Functional;
 
-use PHPUnit\Framework\Attributes\CoversClass;
-use WebVision\Deepltranslate\Core\Client;
-use PHPUnit\Framework\Attributes\Test;
 use DateTime;
 use DeepL\GlossaryEntries;
 use DeepL\GlossaryInfo;
@@ -14,6 +11,9 @@ use DeepL\GlossaryLanguagePair;
 use DeepL\Language;
 use DeepL\TextResult;
 use Helmich\JsonAssert\JsonAssertions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use WebVision\Deepltranslate\Core\Client;
 use WebVision\Deepltranslate\Core\ClientInterface;
 
 #[CoversClass(Client::class)]

--- a/Tests/Functional/Services/DeeplServiceTest.php
+++ b/Tests/Functional/Services/DeeplServiceTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Tests\Functional\Services;
 
+use DeepL\Language;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use DeepL\Language;
 use WebVision\Deepltranslate\Core\Domain\Dto\TranslateContext;
 use WebVision\Deepltranslate\Core\Service\DeeplService;
 use WebVision\Deepltranslate\Core\Service\ProcessingInstruction;

--- a/Tests/Functional/Services/UsageServiceTest.php
+++ b/Tests/Functional/Services/UsageServiceTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Tests\Functional\Services;
 
-use PHPUnit\Framework\Attributes\Test;
 use DeepL\Usage;
 use DeepL\UsageDetail;
+use PHPUnit\Framework\Attributes\Test;
 use WebVision\Deepltranslate\Core\Service\DeeplService;
 use WebVision\Deepltranslate\Core\Service\ProcessingInstruction;
 use WebVision\Deepltranslate\Core\Service\UsageService;


### PR DESCRIPTION
This change adds the dry-run flag (`-n`) to the php-cs-fixer
code-quality execution within the Github Action workflow file
to emit an non-zero exit code when changes are detected to
ensure failing job-run in this case.


Second commit applies php-cs-fixer to get the pipeline green,
which validates that it works again.