### PR TITLE
[TASK] Ensure failing php-cs-fixer within Github Action pipeline (backport #384)

### DIFF
--- a/.github/workflows/testcore11.yml
+++ b/.github/workflows/testcore11.yml
@@ -56,7 +56,7 @@ jobs:
         run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s cgl"
+        run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure tests methods do not start with \"test\""
         run: "Build/Scripts/runTests.sh -t 11 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"

--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -53,7 +53,7 @@ jobs:
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s lintPhp"
 
       - name: "Validate CGL"
-        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl"
+        run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s cgl -n"
 
       - name: "Ensure tests methods do not start with \"test\""
         run: "Build/Scripts/runTests.sh -t 12 -p ${{ matrix.php-version }} -s checkTestMethodsPrefix"

--- a/Tests/Functional/Regression/GlossaryRegressionTest.php
+++ b/Tests/Functional/Regression/GlossaryRegressionTest.php
@@ -93,7 +93,7 @@ final class GlossaryRegressionTest extends AbstractDeepLTestCase
         $dataHandler->start([], $commandMap);
         $dataHandler->process_cmdmap();
 
-        self::assertEmpty($dataHandler->errorLog);
+        static::assertEmpty($dataHandler->errorLog);
         self::assertCSVDataSet(__DIR__ . '/Fixtures/Results/translateWithGlossary.csv');
     }
 }


### PR DESCRIPTION
- **[TASK] Ensure failing `php-cs-fixer` within Github Action pipeline**
  This change adds the dry-run flag (`-n`) to the php-cs-fixer
  code-quality execution within the Github Action workflow file
  to emit an non-zero exit code when changes are detected to
  ensure failing job-run in this case.
  
  Backport of 1b9b3c324b30f090fa4cf044fddb387c47ff272f  of merged #384.
  

- **[TASK] Apply php-cs-fixer changes**
  This change applies `php-cs-fixer` modifications which
  slipped into the code-base because the corresponding
  code-quality check missed the dry-run flag and doesn't
  fail when changes has been detected.
  
  Backport of #384.
  