### PR TITLE
[TASK] Ensure `TestCase::setUp()` parent call chain in tests

### DIFF
--- a/Tests/Unit/Access/AllowedGlossarySyncAccessTest.php
+++ b/Tests/Unit/Access/AllowedGlossarySyncAccessTest.php
@@ -15,6 +15,7 @@ class AllowedGlossarySyncAccessTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->accessInstance = new AllowedGlossarySyncAccess();
     }
 

--- a/Tests/Unit/Access/AllowedTranslateAccessTest.php
+++ b/Tests/Unit/Access/AllowedTranslateAccessTest.php
@@ -15,6 +15,7 @@ class AllowedTranslateAccessTest extends UnitTestCase
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->accessInstance = new AllowedTranslateAccess();
     }
 


### PR DESCRIPTION
Next `typo3/testing-framework` version `8.x`
includes additional integrity checks within
the provided abstract test cases.

That requires that `setUp()` and `tearDown()` calls
needs to hit the parent methods. Some tests overrides
the `setUp()` method in tests but fail to call the
parent method.

This change adds the missing `parent::setUp()` calls to
prepare towards upgrading `typo3/testing-framework`.
