### PR TITLE
[TASK] Ensure to define all depending extension in functional tests

### DIFF
--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -101,6 +101,14 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
     /**
      * @var non-empty-string[]
      */
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-setup',
+        'typo3/cms-scheduler',
+    ];
+
+    /**
+     * @var non-empty-string[]
+     */
     protected array $testExtensionsToLoad = [
         'web-vision/deepltranslate-core',
         __DIR__ . '/Fixtures/Extensions/test_services_override',

--- a/Tests/Functional/Hooks/ButtonBarHookTest.php
+++ b/Tests/Functional/Hooks/ButtonBarHookTest.php
@@ -17,6 +17,11 @@ use WebVision\Deepltranslate\Core\Hooks\ButtonBarHook;
 
 class ButtonBarHookTest extends FunctionalTestCase
 {
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-setup',
+        'typo3/cms-scheduler',
+    ];
+
     protected array $testExtensionsToLoad = [
         'web-vision/deepltranslate-core',
     ];

--- a/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
@@ -16,7 +16,14 @@ final class ExtensionActiveViewHelperTest extends FunctionalTestCase
 {
     protected bool $initializeDatabase = false;
 
-    protected array $testExtensionsToLoad = ['web-vision/deepltranslate-core'];
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-setup',
+        'typo3/cms-scheduler',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'web-vision/deepltranslate-core',
+    ];
 
     protected static FluidCacheInterface $cache;
 


### PR DESCRIPTION
The next `typo3/testing-framework` includes additional
extension dependency check and sorting and will fail to
execute tests when not all extensions are configured as
`$testExtensionToLoad` or `$coreExtensionsToLoad` within
the functional test.

This change adds the missing extension configuration to
functional test cases to prepare the way for the next
`typo3/testing-framework` version and adding TYPO3 v13
suppport.
