### PR TITLE
[TASK] Upgrade to typo3/testing-framework 8.x

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -261,11 +261,6 @@ parameters:
 			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$current of method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Hooks\\\\TranslateHookTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
-			count: 1
-			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
-
-		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
@@ -316,11 +311,6 @@ parameters:
 			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$current of method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\GlossaryRegressionTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
-			count: 1
-			path: ../../../Tests/Functional/Regression/GlossaryRegressionTest.php
-
-		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\LocalizationInlineRegressionTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
@@ -367,11 +357,6 @@ parameters:
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\LocalizationInlineRegressionTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$current of method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\LocalizationInlineRegressionTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
 
@@ -431,11 +416,6 @@ parameters:
 			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$current of method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Services\\\\LanguageServiceTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
-			count: 1
-			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
-
-		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Updates\\\\FormalityUpgradeWizardTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
@@ -482,10 +462,5 @@ parameters:
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Updates\\\\FormalityUpgradeWizardTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
-
-		-
-			message: "#^Parameter \\#1 \\$current of method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Updates\\\\FormalityUpgradeWizardTest\\:\\:mergeInstruction\\(\\) expects TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction, TYPO3\\\\TestingFramework\\\\Core\\\\Functional\\\\Framework\\\\Frontend\\\\Internal\\\\AbstractInstruction\\|null given\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php

--- a/Tests/Functional/Fixtures/Traits/SiteBasedTestTrait.php
+++ b/Tests/Functional/Fixtures/Traits/SiteBasedTestTrait.php
@@ -8,8 +8,8 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\AbstractInstruction;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\ArrayValueInstruction;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\InstructionInterface;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\Internal\TypoScriptInstruction;
 use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use WebVision\Deepltranslate\Core\Tests\Functional\Fixtures\Frontend\PhpError;
@@ -242,13 +242,13 @@ trait SiteBasedTestTrait
     /**
      * @todo Instruction handling should be part of Testing Framework (multiple instructions per identifier, merge in interface)
      */
-    protected function applyInstructions(InternalRequest $request, AbstractInstruction ...$instructions): InternalRequest
+    protected function applyInstructions(InternalRequest $request, InstructionInterface ...$instructions): InternalRequest
     {
         $modifiedInstructions = [];
-
+        $instructions = array_filter($instructions);
         foreach ($instructions as $instruction) {
             $identifier = $instruction->getIdentifier();
-            if (isset($modifiedInstructions[$identifier]) || $request->getInstruction($identifier) !== null) {
+            if (($modifiedInstructions[$identifier] ?? $request->getInstruction($identifier)) !== null) {
                 $modifiedInstructions[$identifier] = $this->mergeInstruction(
                     $modifiedInstructions[$identifier] ?? $request->getInstruction($identifier),
                     $instruction
@@ -261,7 +261,7 @@ trait SiteBasedTestTrait
         return $request->withInstructions($modifiedInstructions);
     }
 
-    protected function mergeInstruction(AbstractInstruction $current, AbstractInstruction $other): AbstractInstruction
+    protected function mergeInstruction(InstructionInterface $current, InstructionInterface $other): InstructionInterface
     {
         if (get_class($current) !== get_class($other)) {
             throw new LogicException('Cannot merge different instruction types', 1565863174);

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
 		"typo3/cms-rte-ckeditor": "^12.4.2",
 		"typo3/cms-tstemplate": "^12.4.2",
 		"typo3/cms-workspaces": "^12.4.2",
-		"typo3/testing-framework": "^7.1.1"
+		"typo3/testing-framework": "^8.2.7"
 	},
 	"suggest": {
         "b13/container": "Just to be loaded after EXT:container",


### PR DESCRIPTION
- **[TASK] Update to `typo3/testing-framework` version 8.x**
  `typo3/testing-framework` supports testing against two
  TYPO3 versions per TF version and the current used 7.x
  supports only TYPO3 v11 and v12.
  
  After TYPO3 v11 support has been dropped, this change
  upgrades the development dependency to the next version
  and bolldozes the towards adding TYPO3 v13 as second
  supported TYPO3 version.
  
  Used command(s):
  
  ```shell
  composer require --dev \
    "typo3/testing-framework":"^8.2.7"
  ```
  

- **[TASK] Use better suiting typing in `SiteBasedTestTrait`**
  The `SiteBasedTestTrait` uses `AbstractInstruction` to declare
  native types for method arguments and return types and PHPStan
  complains about this because `typo3/testing-framework` methods
  uses the `InstructionInterface` instead.
  
  This change adopts `InstructionInterface` type hints to be in
  line with the `typo3/testing-framework` and satisfy PHPStan,
  which allows us to remove no longer matched ignored errors from
  the PHPStan baseline.
  
  Used command(s):
  
  ```shell
  Build/Scripts/runTests.sh -t 12 -p 8.1 -s phpstanGenerateBaseline
  ```
  