### PR TITLE
[TASK] Improve local ddev setup handling - first round

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,6 +133,7 @@
 		"tl": "@php .Build/bin/typoscript-lint",
 		"phpstan": "@php .Build/bin/phpstan",
 		"phpunit": "@php .Build/bin/phpunit",
+		"typo3": "@php .Build/bin/typo3",
 		"cs:check": "@cs fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
 		"cs:fix": "@cs fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
 		"analyze:php:12": "@phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/Core12/phpstan.neon",
@@ -144,7 +145,14 @@
 			"@test:php:functional"
 		],
 		"test:php:unit": "@phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
-		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml"
+		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml",
+		"ddev:setup-instance": [
+			"@typo3 setup --driver=mysqli --host=db --port=3306 --dbname=db --username=db --password=db --project-name=deepltranslate-core --server-type=apache",
+			"@typo3 ddev:generate"
+		]
+	},
+	"scripts-descriptions": {
+		"ddev:setup-instance": "Setup new ddev instance using EXT:styleguide generator"
 	},
 	"repositories": {
 		"local": {

--- a/composer.json
+++ b/composer.json
@@ -106,9 +106,11 @@
 		"typo3/cms-info": "^12.4.2",
 		"typo3/cms-lowlevel": "^12.4.2",
 		"typo3/cms-rte-ckeditor": "^12.4.2",
+		"typo3/cms-styleguide": "^12.0.5",
 		"typo3/cms-tstemplate": "^12.4.2",
 		"typo3/cms-workspaces": "^12.4.2",
-		"typo3/testing-framework": "^8.2.7"
+		"typo3/testing-framework": "^8.2.7",
+		"web-vision/contribution": "@dev"
 	},
 	"suggest": {
         "b13/container": "Just to be loaded after EXT:container",
@@ -143,5 +145,11 @@
 		],
 		"test:php:unit": "@phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
 		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml"
+	},
+	"repositories": {
+		"local": {
+			"type": "path",
+			"url": "packages/*"
+		}
 	}
 }

--- a/packages/contribution/Classes/Command/DdevGenerateCommand.php
+++ b/packages/contribution/Classes/Command/DdevGenerateCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Contribution\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\Deepltranslate\Contribution\Service\SiteStateService;
+
+final class DdevGenerateCommand extends Command
+{
+    public function __construct(
+        private SiteStateService $siteStateService,
+        private CacheManager $cacheManager,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // Make sure the _cli_ user is loaded
+        Bootstrap::initializeBackendAuthentication();
+        $io = new SymfonyStyle($input, $output);
+
+        $statusGenerateFrontendTree = $this->generateStyleGuideFrontendTree($io, $output);
+        if ($statusGenerateFrontendTree !== Command::SUCCESS) {
+            $io->error('!!! Failed !!!');
+            return $statusGenerateFrontendTree;
+        }
+
+        $this->resetState();
+
+        $enableSite = $this->enableSite($io);
+        if ($enableSite !== Command::SUCCESS) {
+            return $enableSite;
+        }
+
+        $io->success('Success ;)');
+        return Command::SUCCESS;
+    }
+
+    private function generateStyleGuideFrontendTree(SymfonyStyle $io, OutputInterface $output): int
+    {
+        $type = ((new Typo3Version())->getMajorVersion() >= 13) ? 'frontend-systemplate' : 'frontend';
+        $io->writeln(sprintf('>> styleguide:generate --create %s', $type));
+        return $this->dispatchSubCommand(
+            $output,
+            'styleguide:generate',
+            [
+                '--create' => true,
+                'type' => $type,
+            ],
+        );
+    }
+
+    private function resetState(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            GeneralUtility::getContainer()->get('cache.core')->flush();
+            GeneralUtility::getContainer()->get('cache.runtime')->flush();
+            $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+            $siteFinder->getAllSites(false);
+        } else {
+            GeneralUtility::getContainer()->get('cache.core')->flush();
+            $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+            $siteFinderReflection = new \ReflectionClass($siteFinder);
+            $siteFinderReflection->getProperty('sites')->setValue($siteFinder, []);
+            $siteFinder->getAllSites(false);
+        }
+    }
+
+    private function enableSite(SymfonyStyle $io): int
+    {
+        try {
+            $this->siteStateService->enableSite($io);
+            return Command::SUCCESS;
+        } catch (\Throwable $t) {
+            $io->error($t->getMessage());
+            return Command::FAILURE;
+        }
+    }
+
+    private function dispatchSubCommand(
+        OutputInterface $output,
+        string $command,
+        array $parameters = [],
+    ): int {
+        $options = [
+            'command' => $command,
+        ];
+        $options = array_merge($options, $parameters);
+        $input = new ArrayInput($options);
+        $input->setInteractive(false);
+        return $this->getApplication()->doRun($input, $output);
+    }
+}

--- a/packages/contribution/Classes/Service/SiteStateService.php
+++ b/packages/contribution/Classes/Service/SiteStateService.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Contribution\Service;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final class SiteStateService
+{
+    public function __construct(
+        private SiteFinder $siteFinder,
+        private ConnectionPool $connectionPool,
+    ) {
+    }
+
+    public function enableSite(SymfonyStyle $io): void
+    {
+        $this->resetState();
+        $allSites = $this->siteFinder->getAllSites(false);
+        if ($allSites === []) {
+            throw new \RuntimeException(
+                sprintf('No sites found in %s', __METHOD__),
+                1734010952,
+            );
+        }
+        foreach ($allSites as $site) {
+            $io->write(sprintf(
+                'Enable site "%s"[RootPID: %s][URI: %s] ... ',
+                $site->getIdentifier(),
+                $site->getRootPageId(),
+                $this->getSiteBaseUri($site),
+            ));
+            $record = $this->getRecord($site->getRootPageId());
+            if ($record === null) {
+                $io->writeln('<error>not found</error>');
+                continue;
+            }
+            $this->updatePage($site->getRootPageId(), ['hidden' => 0]);
+            $io->writeln('<info>enabled</info>');
+        }
+    }
+
+    public function disableSite(SymfonyStyle $io): void
+    {
+        $this->resetState();
+        $allSites = $this->siteFinder->getAllSites(false);
+        if ($allSites === []) {
+            throw new \RuntimeException(
+                sprintf('No sites found in %s', __METHOD__),
+                1734010933,
+            );
+        }
+        foreach ($allSites as $site) {
+            $io->write(sprintf(
+                'Disable site "%s"[RootPID: %s][URI: %s] ... ',
+                $site->getIdentifier(),
+                $site->getRootPageId(),
+                $this->getSiteBaseUri($site),
+            ));
+            $record = $this->getRecord($site->getRootPageId());
+            if ($record === null) {
+                $io->writeln('<error>not found</error>');
+                continue;
+            }
+            $this->updatePage($site->getRootPageId(), ['hidden' => 1]);
+            $io->writeln('<info>disabled</info>');
+        }
+    }
+
+    private function getSiteBaseUri(Site $site): string
+    {
+        $primaryUrl = rtrim((string)(getenv('DDEV_PRIMARY_URL') ?: ''), '/');
+        $baseUri = ltrim((string)$site->getBase(), '/');
+        return ltrim($primaryUrl . '/' . $baseUri, '/');
+    }
+
+    public function getRecord(int $pageId): ?array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('pages');
+        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
+        return $queryBuilder
+            ->select('*')
+            ->from('pages')
+            ->where(
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($pageId, Connection::PARAM_INT)),
+            )
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative() ?: null;
+    }
+
+    public function updatePage(int $pageId, array $data): void
+    {
+        $this->connectionPool->getConnectionForTable('pages')
+            ->update('pages', $data, ['uid' => $pageId]);
+    }
+
+    private function resetState(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            GeneralUtility::getContainer()->get('cache.core')->flush();
+            GeneralUtility::getContainer()->get('cache.runtime')->flush();
+            $this->siteFinder->getAllSites(false);
+        } else {
+            GeneralUtility::getContainer()->get('cache.core')->flush();
+            $siteFinderReflection = new \ReflectionClass($this->siteFinder);
+            $siteFinderReflection->getProperty('sites')->setValue($this->siteFinder, []);
+            $this->siteFinder->getAllSites(false);
+        }
+    }
+}

--- a/packages/contribution/Configuration/Services.yaml
+++ b/packages/contribution/Configuration/Services.yaml
@@ -1,0 +1,16 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  WebVision\Deepltranslate\Contribution\:
+    resource: '../Classes/*'
+
+  WebVision\Deepltranslate\Contribution\Command\DdevGenerateCommand:
+    tags:
+      - name: 'console.command'
+        command: 'ddev:generate'
+        description: 'Generates EXT:styleguide page trees and activates the frontend page.'
+        schedulable: false
+

--- a/packages/contribution/composer.json
+++ b/packages/contribution/composer.json
@@ -1,0 +1,50 @@
+{
+    "name": "web-vision/contribution",
+    "description": "Collection of contribution helper for extension ddev environment",
+    "type": "typo3-cms-extension",
+    "license": "GPL-2.0-or-later",
+    "autoload": {
+        "psr-4": {
+            "WebVision\\Deepltranslate\\Contribution\\": "Classes/"
+        }
+    },
+    "authors": [
+		{
+			"name": "web-vision GmbH",
+			"email": "hello@web-vision.de",
+			"role": "Maintainer"
+		},
+		{
+			"name": "Mark Houben",
+			"email": "markhouben91@gmail.com",
+			"role": "Developer"
+		},
+		{
+			"name": "Markus Hofmann",
+			"email": "typo3@calien.de",
+			"role": "Developer"
+		},
+		{
+			"name": "Riad Zejnilagic Trumic",
+			"role": "Developer"
+		},
+		{
+			"name": "Stefan Bürk",
+			"role": "Developer",
+			"email": "stefan@buerk.tech"
+		}
+    ],
+    "require": {
+        "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+        "typo3/cms-core": "^12.4.2",
+        "typo3/cms-backend": "^12.4.2",
+        "typo3/cms-frontend": "^12.4.2",
+        "typo3/cms-install": "^12.4.2",
+        "typo3/cms-setup": "^12.4.2"
+    },
+    "extra": {
+        "typo3/cms": {
+            "extension-key": "contribution"
+        }
+    }
+}

--- a/packages/contribution/ext_emconf.php
+++ b/packages/contribution/ext_emconf.php
@@ -1,0 +1,29 @@
+<?php
+
+$EM_CONF[$_EXTKEY] = [
+    'title' => 'DeepL Translate - Contribution Helper',
+    'description' => 'Collection of contribution helper for extension ddev environment',
+    'category' => 'backend',
+    'author' => 'web-vision GmbH Team',
+    'author_company' => 'web-vision GmbH',
+    'author_email' => 'hello@web-vision.de',
+    'state' => 'stable',
+    'version' => '1.0.0',
+    'constraints' => [
+        'depends' => [
+            'php' => '8.1.0-8.4.99',
+            'typo3' => '12.4.0-12.4.99',
+            'backend' => '12.4.0-12.4.99',
+            'frontend' => '12.4.0-12.4.99',
+            'install' => '12.4.0-12.4.99',
+            'setup' => '12.4.0-12.4.99',
+        ],
+        'conflicts' => [],
+        'suggests' => [],
+    ],
+    'autoload' => [
+        'psr-4' => [
+            'WebVision\\Deepltranslate\\Core\\' => 'Classes',
+        ],
+    ],
+];


### PR DESCRIPTION
- **[TASK] Introduce local patch `contribution` package/extension**
  To make contribution and workin on `EXT:deepltranslate_core` easier,
  the provided ddev based local environment should be improved with
  the ability to setup a basic working environment easily.
  
  This change introduces a local development extension `EXT:contribution`
  as preparation to give at least a simple and easy setup of a running
  TYPO3 instance based on the TYPO3 `EXT:styleguide` core extension to
  generate a backend and frontend tree / data. Combined with the TYPO3
  v12 setup command this allows a simple instance generation.
  
  For the start, the contribution extension only provide a cli command
  to manage site root visibilities (on/off) having `EXT:styleguide`
  generated trees in mind.
  

- **[TASK] Add `EXT:styleguide` and `EXT:contribution` as development dependencies**
  To improve the extension contribution experience with the
  provided ddev setup two additional development dependencies
  are added:
  
  * `EXT:styleguide`: TYPO3 Core development extension which
    provides a generator for TCA and FRONTEND page trees.
  * `EXT:contribution`: Local path extension providing some
    helper arround the contribution/working experience for
    the ddev instance.
  
  ```terminal
  composer config sort-packages true
  composer config repositories.local path "packages/*"
  composer require --dev \
    "typo3/cms-styleguide":"^12.0.5" \
    "web-vision/contribution":"@dev"
  ```
  
  composer2-81 config sort-packages true
  composer2-81 config repositories.local path "packages/*"
  composer2-81 require --dev \
    "typo3/cms-styleguide":"^12.0.5" \
    "web-vision/contribution":"@dev"
  

- **[TASK] Add `ddev-setup-instance` composer script**
  This change adds the composer script `ddev:setup-instance`,
  which setupts the TYPO3 instance for ddev, generates the
  `EXT:styleguide` trees and activates the frontend site.
  