### PR TITLE
[TASK] Mitigate renamed doctrine exception class

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -36,24 +36,9 @@ parameters:
 			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
 
 		-
-			message: "#^PHPDoc tag @throws with type Doctrine\\\\DBAL\\\\DBALException\\|Doctrine\\\\DBAL\\\\Driver\\\\Exception\\|Doctrine\\\\DBAL\\\\Exception is not subtype of Throwable$#"
-			count: 3
-			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
-			message: "#^PHPDoc tag @throws with type Doctrine\\\\DBAL\\\\DBALException\\|Doctrine\\\\DBAL\\\\Driver\\\\Exception\\|Doctrine\\\\DBAL\\\\Exception\\|TYPO3\\\\CMS\\\\Core\\\\Exception\\\\SiteNotFoundException is not subtype of Throwable$#"
-			count: 1
-			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
 			message: "#^Parameter \\#3 \\$page of method WebVision\\\\Deepltranslate\\\\Core\\\\Domain\\\\Repository\\\\GlossaryRepository\\:\\:getGlossaryBySourceAndTargetForSync\\(\\) expects array\\{uid\\: int, title\\: string\\}, array\\|null given\\.$#"
 			count: 1
 			path: ../../../Classes/Domain/Repository/GlossaryRepository.php
-
-		-
-			message: "#^PHPDoc tag @throws with type Doctrine\\\\DBAL\\\\DBALException\\|Doctrine\\\\DBAL\\\\Driver\\\\Exception is not subtype of Throwable$#"
-			count: 1
-			path: ../../../Classes/Domain/Repository/PageTreeRepository.php
 
 		-
 			message: "#^Cannot call method getRequestUri\\(\\) on TYPO3\\\\CMS\\\\Core\\\\Http\\\\NormalizedParams\\|null\\.$#"
@@ -79,11 +64,6 @@ parameters:
 			message: "#^There is no aspect \"frontend\\.preview\" configured so we can't figure out the exact type to return when calling TYPO3\\\\CMS\\\\Core\\\\Context\\\\Context\\:\\:getPropertyFromAspect$#"
 			count: 1
 			path: ../../../Classes/Hooks/DeeplPreviewFlagGeneratePageHook.php
-
-		-
-			message: "#^PHPDoc tag @throws with type Doctrine\\\\DBAL\\\\DBALException\\|Doctrine\\\\DBAL\\\\Driver\\\\Exception\\|TYPO3\\\\CMS\\\\Core\\\\Exception is not subtype of Throwable$#"
-			count: 1
-			path: ../../../Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
 
 		-
 			message: "#^Parameter \\#1 \\$uid of method WebVision\\\\Deepltranslate\\\\Core\\\\Domain\\\\Repository\\\\GlossaryEntryRepository\\:\\:findEntryByUid\\(\\) expects int, int\\|string given\\.$#"

--- a/Classes/Domain/Repository/GlossaryRepository.php
+++ b/Classes/Domain/Repository/GlossaryRepository.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Domain\Repository;
 
 use DeepL\GlossaryInfo;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Backend\Configuration\TranslationConfigurationProvider;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Connection;

--- a/Classes/Domain/Repository/PageTreeRepository.php
+++ b/Classes/Domain/Repository/PageTreeRepository.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Domain\Repository;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryHelper;

--- a/Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
+++ b/Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Hooks\Glossary;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Exception;
+use Doctrine\DBAL\Exception as DBALException;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;


### PR DESCRIPTION
Doctrine DBAL 3.x renamed one exception class as a
breaking change and this change replaces occurances
to respect this.

Used command(s):

```shell
Build/Scripts/runTests.sh -t 12 -p 8.1 -s phpstanGenerateBaseline
```

[1] https://github.com/doctrine/dbal/blob/3.9.3/UPGRADE.md#bc-break-doctrinedbaldbalexception-class-renamed
