### PR TITLE
[TASK] Avoid obsolete `version` in `.ddev/docker-compose.deeplmockserver.yml`

### DIFF
--- a/.ddev/docker-compose.deeplmockserver.yml
+++ b/.ddev/docker-compose.deeplmockserver.yml
@@ -1,5 +1,3 @@
-version: '3.6'
-
 services:
   # This is the service name used when running ddev commands accepting the
   # --service flag.


### PR DESCRIPTION
docker-compose made the `version` option in the `docker-compose.yml`
syntax obsolete and throws notices. As docker is usualy kept up2date
and these version are out already a long time we can remove that
option to avoid the following notice on ddev start:

```
time="2024-12-12T14:26:54+01:00"
level=warning
msg="/var/www/work/webvision/wv_deepltranslate/.ddev/docker-compose.deeplmockserver.yml:
the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"
```
