### PR TITLE
[TASK] Migrate upgrade wizards registration

### DIFF
--- a/Classes/Upgrades/FormalityUpgradeWizard.php
+++ b/Classes/Upgrades/FormalityUpgradeWizard.php
@@ -10,11 +10,13 @@ use Symfony\Component\Yaml\Yaml;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\ChattyInterface;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 use WebVision\Deepltranslate\Core\Service\DeeplService;
 
+#[UpgradeWizard('wvDeepltranslate_formalityUpgrade')]
 class FormalityUpgradeWizard implements UpgradeWizardInterface, ChattyInterface
 {
     protected OutputInterface $output;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,9 +3,6 @@
 defined('TYPO3') or die();
 
 (static function (): void {
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['wvDeepltranslate_formalityUpgrade']
-        = \WebVision\Deepltranslate\Core\Upgrades\FormalityUpgradeWizard::class;
-
     //allowLanguageSynchronizationHook manipulates l10n_state
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
         = \WebVision\Deepltranslate\Core\Hooks\AllowLanguageSynchronizationHook::class;


### PR DESCRIPTION
Since TYPO3 12.2 [1] registration upgrade wizards using the
`$GLOBALS` array has been deprecated in favour of using the
new PHP attribute `#[UpgradeWizard('myUpgradeWizard')]`.

This change adopts the new way of registering upgrade
following the migration path given in the changelog entry.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.2/Deprecation-99586-RegistrationOfUpgradeWizardsViaGLOBALS.html
