### PR TITLE
[TASK] Avoid using deprecated `SiteLanguage->getTwoLetterCode()`

### DIFF
--- a/Classes/ViewHelpers/DeeplTranslateViewHelper.php
+++ b/Classes/ViewHelpers/DeeplTranslateViewHelper.php
@@ -44,8 +44,8 @@ class DeeplTranslateViewHelper extends AbstractViewHelper
             ) {
                 if ($mode === self::GLOSSARY_MODE) {
                     if (!DeeplBackendUtility::checkGlossaryCanCreated(
-                        $context->getSiteLanguage()->getTwoLetterIsoCode(),
-                        $siteLanguage->getTwoLetterIsoCode()
+                        $context->getSiteLanguage()->getLocale()->getLanguageCode(),
+                        $siteLanguage->getLocale()->getLanguageCode()
                     )
                     ) {
                         continue;


### PR DESCRIPTION
TYPO3 v12.2 deprecated the `SiteLanguage->getTwoLetterCode()` method
in favour of `SiteLanguage->getLocale()->getLanguageCode()`.

This change migrates all occurances throughout the code base as an
investment into the future.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Deprecation-99905-SiteLanguageIso-639-1Setting.html#deprecation-99905-site-language-iso-639-1-setting
[2] https://forge.typo3.org/issues/99905
[3] https://review.typo3.org/c/Packages/TYPO3.CMS/+/77597
