### PR TITLE
[BUGFIX] Ender preview translated flag information in TYPO3 v12 (5.x)

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -61,11 +61,6 @@ parameters:
 			path: ../../../Classes/Hooks/ButtonBarHook.php
 
 		-
-			message: "#^There is no aspect \"frontend\\.preview\" configured so we can't figure out the exact type to return when calling TYPO3\\\\CMS\\\\Core\\\\Context\\\\Context\\:\\:getPropertyFromAspect$#"
-			count: 1
-			path: ../../../Classes/Hooks/DeeplPreviewFlagGeneratePageHook.php
-
-		-
 			message: "#^Parameter \\#1 \\$uid of method WebVision\\\\Deepltranslate\\\\Core\\\\Domain\\\\Repository\\\\GlossaryEntryRepository\\:\\:findEntryByUid\\(\\) expects int, int\\|string given\\.$#"
 			count: 1
 			path: ../../../Classes/Hooks/Glossary/UpdatedGlossaryEntryTermHook.php

--- a/Build/phpstan/Core12/phpstan.neon
+++ b/Build/phpstan/Core12/phpstan.neon
@@ -16,3 +16,7 @@ parameters:
     - ../../../.Build/*
     - ../../../Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_emconf.php
     - ../../../Tests/Functional/Fixtures/Extensions/test_services_override/ext_emconf.php
+
+  typo3:
+    contextApiGetAspectMapping:
+      'frontend.preview': TYPO3\CMS\Frontend\Aspect\PreviewAspect

--- a/Classes/Event/Listener/RenderTranslatedFlagInFrontendPreviewMode.php
+++ b/Classes/Event/Listener/RenderTranslatedFlagInFrontendPreviewMode.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Event\Listener;
+
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\Event\AfterCacheableContentIsGeneratedEvent;
+use WebVision\Deepltranslate\Core\Hooks\DeeplPreviewFlagGeneratePageHook;
+
+/**
+ * Event listener to render the frontend preview flag information.
+ *
+ * TYPO3 v12+ only and this is the counter-part of the {@see DeeplPreviewFlagGeneratePageHook} for older TYPO3 versions.
+ * https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97862-HooksRelatedToGeneratingPageContentRemoved.html
+ */
+final class RenderTranslatedFlagInFrontendPreviewMode
+{
+    public function __invoke(AfterCacheableContentIsGeneratedEvent $event): void
+    {
+        $controller = $this->getTypoScriptFrontendController($event);
+        $context = $controller->getContext();
+        if (
+            !$this->isInPreviewMode($context)
+            || $this->processWorkspacePreview($context)
+            || ($controller->config['config']['disablePreviewNotification'] ?? false)
+            || (
+                isset($controller->page['tx_wvdeepltranslate_translated_time'])
+                && $controller->page['tx_wvdeepltranslate_translated_time'] === 0
+            )
+        ) {
+            // Preview flag must not be inserted. Return early.
+            return;
+        }
+
+        $messagePreviewLabel = ($controller->config['config']['deepl_message_preview'] ?? '')
+            ?: 'Translated with DeepL';
+
+        $styles = [];
+        $styles[] = 'position: fixed';
+        $styles[] = 'top: 65px';
+        $styles[] = 'right: 15px';
+        $styles[] = 'padding: 8px 18px';
+        $styles[] = 'background: #006494';
+        $styles[] = 'border: 1px solid #006494';
+        $styles[] = 'font-family: sans-serif';
+        $styles[] = 'font-size: 14px';
+        $styles[] = 'font-weight: bold';
+        $styles[] = 'color: #fff';
+        $styles[] = 'z-index: 20000';
+        $styles[] = 'user-select: none';
+        $styles[] = 'pointer-events: none';
+        $styles[] = 'text-align: center';
+        $styles[] = 'border-radius: 2px';
+        $message = '<div id="deepl-preview-info" style="' . implode(';', $styles) . '">' . htmlspecialchars($messagePreviewLabel) . '</div>';
+
+        $controller->content = str_ireplace('</body>', $message . '</body>', $controller->content);
+    }
+
+    private function isInPreviewMode(Context $context): bool
+    {
+        return $context->hasAspect('frontend.preview')
+            && $context->getPropertyFromAspect('frontend.preview', 'isPreview', false);
+    }
+
+    private function processWorkspacePreview(Context $context): bool
+    {
+        return $context->hasAspect('workspace')
+            && $context->getPropertyFromAspect('workspace', 'isOffline', false);
+    }
+
+    private function getTypoScriptFrontendController(AfterCacheableContentIsGeneratedEvent $event): TypoScriptFrontendController
+    {
+        return $event->getController();
+    }
+}

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -19,6 +19,7 @@ use WebVision\Deepltranslate\Core\Command\GlossarySyncCommand;
 use WebVision\Deepltranslate\Core\Controller\Backend\AjaxController;
 use WebVision\Deepltranslate\Core\Controller\GlossarySyncController;
 use WebVision\Deepltranslate\Core\Event\Listener\GlossarySyncButtonProvider;
+use WebVision\Deepltranslate\Core\Event\Listener\RenderTranslatedFlagInFrontendPreviewMode;
 use WebVision\Deepltranslate\Core\Event\Listener\UsageToolBarEventListener;
 use WebVision\Deepltranslate\Core\Form\Item\SiteConfigSupportedLanguageItemsProcFunc;
 use WebVision\Deepltranslate\Core\Form\User\HasFormalitySupport;
@@ -160,6 +161,18 @@ return function (ContainerConfigurator $containerConfigurator, ContainerBuilder 
                 'event' => SystemInformationToolbarCollectorEvent::class,
             ]
         );
+
+    if ((new Typo3Version())->getMajorVersion() >= 12) {
+        // @todo Unnest this in next major when TYPO3 v11 support has been removed.
+        $services
+            ->set(RenderTranslatedFlagInFrontendPreviewMode::class)
+            ->tag(
+                'event.listener',
+                [
+                    'identifier' => 'deepltranslate-core/render-translated-flag-in-frontend-preview-mode',
+                ]
+            );
+    }
 
     /**
      * Check if WidgetRegistry is defined, which means that EXT:dashboard is available.

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,6 +3,8 @@
 defined('TYPO3') or die();
 
 (static function (): void {
+    $typo3version = new \TYPO3\CMS\Core\Information\Typo3Version();
+
     //allowLanguageSynchronizationHook manipulates l10n_state
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][]
         = \WebVision\Deepltranslate\Core\Hooks\AllowLanguageSynchronizationHook::class;
@@ -24,8 +26,11 @@ defined('TYPO3') or die();
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['checkModifyAccessList']['deepl']
         = \WebVision\Deepltranslate\Core\Hooks\TCEmainHook::class;
 
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all']['deepl-1675946132'] =
-        \WebVision\Deepltranslate\Core\Hooks\DeeplPreviewFlagGeneratePageHook::class . '->renderDeeplPreviewFlag';
+    if ($typo3version->getMajorVersion() < 12) {
+        // @todo Remove when TYPO3 v11 support is removed.
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all']['deepl-1675946132'] =
+            \WebVision\WvDeepltranslate\Hooks\DeeplPreviewFlagGeneratePageHook::class . '->renderDeeplPreviewFlag';
+    }
 
     //xclass localizationcontroller for localizeRecords() and process() action
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Backend\Controller\Page\LocalizationController::class] = [


### PR DESCRIPTION
TYPO3 v12 removed the `contentPostProc-all` aling with other hooks
in favour of new PSR-14 `AfterCacheableContentIsGeneratedEvent`.

The `DeeplPreviewFlagGeneratePageHook` is not called in TYPO3 v12
anymore and the translated preview flag is not displayed. Changed
behavour between TYPO3 v11 and v12 was not intented and simply an
oversight to mitigate when adding TYPO3 v12 support. Sadly, this
has not been detected for quite a while now.

This change introduces a event listener for the TYPO3 v12 event,
rendering the same flag to restore the missing and wanted preview
flag while keeping the hook implementation for TYPO3 v11 instances.
Choosen strategy follows the recommended way to migrate from the
hook to the event when dual TYPO3 version support is required.

Used command(s):

```base
Build/Scripts/runTests.sh -t 12 -p 8.1 -s composerUpdate
Build/Scripts/runTests.sh -t 12 -p 8.1 -s phpstanGenerateBaseline
```

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-97862-HooksRelatedToGeneratingPageContentRemoved.html
[2] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-97862-NewPSR-14EventsForManipulatingFrontendPageGenerationAndCacheBehaviour.html

**TYPO3 v12 with this change**

![image](https://github.com/user-attachments/assets/3876a2fc-946d-46a6-8ec2-51b4fc8fea1e)

Resolves: #395
