### PR TITLE
[TASK] Add `sbuerk/typo3-cms-styleguide-version-sync` development dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
 		"phpunit/phpunit": "^10.5",
 		"ramsey/uuid": "^4.2",
 		"saschaegerer/phpstan-typo3": "^1.9",
+		"sbuerk/typo3-cms-styleguide-version-sync": "^12",
 		"typo3/cms-belog": "^12.4.2",
 		"typo3/cms-dashboard": "^12.4.2",
 		"typo3/cms-extensionmanager": "^12.4.2",


### PR DESCRIPTION
The `typo3/cms-styleguide` package does not have requires towards
concrete TYPO3 system extension(s), which leads to side-effects
when trying to have multiple version for multi-core composer.json's
and let composer installalling suitable styleguide version for core
version.

The `sbuerk/typo3-cms-styleguide-version-sync` package has been
created as meta package to mitigate this issues acting as version
bridge.

As preparation for adding TYPO3 v13 support requiring dual versions,
we add it now for v12 only as a starting point and are forced to
update it when adding v13 support along the way.

Used command(s):

```bash
composer require --dev \
  "sbuerk/typo3-cms-styleguide-version-sync":"^12"
```
