### PR TITLE
[TASK] Add `typo3/cms-styleguide` along with version selector meta package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
 		"phpunit/phpunit": "^9.6.8 || ^10.1",
 		"ramsey/uuid": "^4.2",
 		"saschaegerer/phpstan-typo3": "^1.9",
+		"sbuerk/typo3-styleguide-selector": "^11.5.5 || ^12.0.5",
 		"typo3/cms-belog": "^11.5 || ^12.4",
 		"typo3/cms-dashboard": "^11.5 || ^12.4",
 		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
@@ -101,6 +102,7 @@
 		"typo3/cms-info": "^11.5 || ^12.4",
 		"typo3/cms-lowlevel": "^11.5 || ^12.4",
 		"typo3/cms-rte-ckeditor": "^11.5 || ^12.4",
+		"typo3/cms-styleguide": "^11 || ^12",
 		"typo3/cms-tstemplate": "^11.5 || ^12.4",
 		"typo3/cms-workspaces": "^11.5 || ^12.4",
 		"typo3/testing-framework": "^7.0"


### PR DESCRIPTION
This change adds the `typo3/cms-styleguide` extension as a new development
dependency to allow setting up a content tree within the local development
instance using ddev.

The styleguide package does not contain core system extension dependency
configuration and composer would therefore install the highest version,
even if not compatible when lower TYPO3 core version is used.

To mitigate this issue, the `sbuerk/typo3-styleguide-selector` is also
added to help composer selecting the correct version based on the real
TYPO3 version installed.

Used command(s):

```bash
composer require --dev --no-update \
  "typo3/cms-styleguide":"^11 || ^12" \
  "sbuerk/typo3-styleguide-selector":"^11.5.5 || ^12.0.5"
```
