### PR TITLE
[TASK] Make ProcessingInstructions public service for 4.x

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -88,7 +88,8 @@ return function (ContainerConfigurator $containerConfigurator, ContainerBuilder 
 
     $services
         ->set(ProcessingInstruction::class)
-        ->arg('$runtimeCache', service('cache.runtime'));
+        ->arg('$runtimeCache', service('cache.runtime'))
+        ->public();
     $services
         ->set(DeeplService::class)
         ->public()


### PR DESCRIPTION
As other services can use the DeeplService and translate by their own, it's necessary to be able to override the ProcessingInstruction setting DeepL mode to true. As this is not the default and inside the core extension only needed for the command map, the service has to be made public, allowing external services adjusting the instructions.