### PR TITLE
[TASK] Use simplified backend module template for `UsageWidget`

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -4,16 +4,16 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use TYPO3\CMS\Backend\View\BackendViewFactory;
 use TYPO3\CMS\Core\DependencyInjection\SingletonPass;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Dashboard\WidgetRegistry;
-use WebVision\Deepltranslate\Core\Core12\Widgets\UsageWidget as Core12UsageWidget;
 use WebVision\Deepltranslate\Core\Form\Item\SiteConfigSupportedLanguageItemsProcFunc;
 use WebVision\Deepltranslate\Core\Form\User\HasFormalitySupport;
 use WebVision\Deepltranslate\Core\Hooks\TranslateHook;
+use WebVision\Deepltranslate\Core\Service\UsageService;
+use WebVision\Deepltranslate\Core\Widgets\UsageWidget;
 
 return function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder) {
-    $typo3version = new Typo3Version();
     $services = $containerConfigurator
         ->services();
 
@@ -39,26 +39,19 @@ return function (ContainerConfigurator $containerConfigurator, ContainerBuilder 
      * Registration directly in Services.yaml will break without EXT:dashboard installed!
      */
     if ($containerBuilder->hasDefinition(WidgetRegistry::class)) {
-        if ($typo3version->getMajorVersion() >= 13) {
-            // @todo Register TYPO3 v13 compatible UsageWidget implementation. (StandaloneView => ViewFactory)
-        }
-        /**
-         * @todo Remove core12 usage widget when TYPO3 v12 support is removed along with {@see Core11UsageWidget}.
-         */
-        if ($typo3version->getMajorVersion() === 12) {
-            $services->set('widgets.deepltranslate.widget.useswidget')
-                ->class(Core12UsageWidget::class)
-                ->arg('$view', new Reference('dashboard.views.widget'))
-                ->arg('$options', [])
-                ->tag('dashboard.widget', [
-                    'identifier' => 'widgets-deepl-uses',
-                    'groupNames' => 'deepl',
-                    'title' => 'LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.title',
-                    'description' => 'LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.description',
-                    'iconIdentifier' => 'content-widget-list',
-                    'height' => 'small',
-                    'width' => 'small',
-                ]);
-        }
+        $services->set('widgets.deepltranslate.widget.useswidget')
+            ->class(UsageWidget::class)
+            ->arg('$backendViewFactory', new Reference(BackendViewFactory::class))
+            ->arg('$usageService', new Reference(UsageService::class))
+            ->arg('$options', [])
+            ->tag('dashboard.widget', [
+                'identifier' => 'widgets-deepl-uses',
+                'groupNames' => 'deepl',
+                'title' => 'LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.title',
+                'description' => 'LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.description',
+                'iconIdentifier' => 'content-widget-list',
+                'height' => 'small',
+                'width' => 'small',
+            ]);
     }
 };

--- a/Resources/Private/Backend/Templates/Widget/UsageWidget.html
+++ b/Resources/Private/Backend/Templates/Widget/UsageWidget.html
@@ -17,13 +17,11 @@
             <f:if condition="{percentage} >= 100">
                 <f:variable name="severity" value="danger" />
             </f:if>
-            <p>
-                <f:translate
-                    key="LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.message"
-                    arguments="{0: count, 1: limit}"
-                />
-            </p>
-            <div class="progress" role="progressbar" aria-label="Usage" aria-valuenow="{procss}" aria-valuemin="0" aria-valuemax="100" style="height: 50%">
+            <span><f:translate
+                key="LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:widgets.deepltranslate.widget.useswidget.message"
+                arguments="{0: count, 1: limit}"
+            /></span>
+            <div class="progress" role="progressbar" aria-label="Usage" aria-valuenow="{procss}" aria-valuemin="0" aria-valuemax="100" style="height: 20%">
                 <div class="progress-bar" style="width: {percentage}%; --bs-progress-bar-bg: var(--bs-{severity -> f:or(alternative: 'info')});">&nbsp;</div>
             </div>
         </div>


### PR DESCRIPTION
TYPO3 v12 introduced a simplified ext:backend ModuleTemplate API [1]
to avoid the use of `StandaloneView` in the backend context and it's
not a suprise that TYPO3 v13 continued on this path and deprecated
it in TYPO3 13.3 [2] finally removing it as breaking change in TYPO3
v14 [3].

Sounding quite challenging, it's quite easy to make the `UsageWidget`
for `EXT:dashboard` compatible with TYPO3 v12 and v13 using simplified
backend module template API directly with the template override [4]
feature already included.

The surrounding `<p>` tag in the fluid template for the usage text
is replaced with `<span>` to make the UX feeling more user-friendly.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96730-SimplifiedExtbackendModuleTemplateAPI.html
[2] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.3/Deprecation-104773-CustomFluidViewsAndExtbase.html
[3] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-105377-DeprecatedFunctionalityRemoved.html
[4] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96812-OverrideBackendTemplatesWithTSconfig.html

**TYPO3 v12**

![image](https://github.com/user-attachments/assets/0f3bf327-538f-445f-8b92-ba59adf9802a)

**TYPO3 v13 DarkMode**

![image](https://github.com/user-attachments/assets/3d577568-f2cb-49f6-b4f1-f445b66201bd)

