### PR TITLE
[!!!][TASK] Mitigate depecated flash message severity

### DIFF
--- a/Classes/Hooks/AbstractTranslateHook.php
+++ b/Classes/Hooks/AbstractTranslateHook.php
@@ -10,6 +10,7 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Domain\Dto\TranslateContext;
 use WebVision\Deepltranslate\Core\Domain\Repository\PageRepository;
@@ -98,7 +99,7 @@ abstract class AbstractTranslateHook
         return $pageId;
     }
 
-    protected function flashMessages(string $message, string $title, int $severity): void
+    protected function flashMessages(string $message, string $title, ContextualFeedbackSeverity $severity): void
     {
         if (Environment::isCli() || Environment::getContext()->isTesting()) {
             return;

--- a/Classes/Hooks/TranslateHook.php
+++ b/Classes/Hooks/TranslateHook.php
@@ -7,6 +7,7 @@ namespace WebVision\Deepltranslate\Core\Hooks;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
@@ -65,14 +66,14 @@ class TranslateHook extends AbstractTranslateHook
                 $this->flashMessages(
                     'Translation not successful', // ToDo use locallang label
                     '',
-                    -1
+                    ContextualFeedbackSeverity::INFO
                 );
             }
         } catch (LanguageIsoCodeNotFoundException|LanguageRecordNotFoundException $e) {
             $this->flashMessages(
                 $e->getMessage(),
                 '',
-                -1 // Info
+                ContextualFeedbackSeverity::INFO
             );
         }
 


### PR DESCRIPTION
Since TYPO3 v12 the flash message severity are deprecated in favour of
the `ContextualFeedbackSeverity` and will fail in TYPO3 v13.

This change mitigates the deprecation and removal by directly using the
native PHP Enum for TYPO3 v12 and TYPO3 v13 by:

* Changing signature of `AbstractTranslateHook::flashMessages()` from
  integer to `ContextualFeedbackSeverity`.
* Replace integer `-1` with `ContextualFeedbackSeverity::INFO` in two
  places within `TranslateHook`. Something addon extensions needs to
  handle on their own.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-97787-SeveritiesOfFlashMessagesAndReportsDeprecated.html
