### PR TITLE
[TASK] Make functional tests executable for both core versions

### DIFF
--- a/Build/Scripts/composer-for-core-version.sh
+++ b/Build/Scripts/composer-for-core-version.sh
@@ -6,6 +6,7 @@
 composer_cleanup() {
     echo -e "💥 Cleanup folders"
     rm -Rf \
+        .cache/phpstan/* \
         .Build/vendor/* \
         .Build/var/* \
         .Build/bin/* \

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -41,6 +41,11 @@ parameters:
 			path: ../../../Classes/Service/LanguageService.php
 
 		-
+			message: "#^Call to method write\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
+			count: 1
+			path: ../../../Classes/Upgrades/FormalityUpgradeWizard.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Utility\\\\DeeplBackendUtility\\:\\:buildBackendRoute\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Classes/Utility/DeeplBackendUtility.php
@@ -106,6 +111,16 @@ parameters:
 			path: ../../../Tests/Functional/Fixtures/Frontend/PhpError.php
 
 		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Hooks\\\\TranslateHookTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
@@ -154,6 +169,26 @@ parameters:
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Hooks\\\\TranslateHookTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$eventDispatcher of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects Psr\\\\EventDispatcher\\\\EventDispatcherInterface, TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\LocalizationInlineRegressionTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -206,6 +241,26 @@ parameters:
 			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$eventDispatcher of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects Psr\\\\EventDispatcher\\\\EventDispatcherInterface, TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\PreviewTranslationInformationTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
@@ -256,9 +311,29 @@ parameters:
 			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$eventDispatcher of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects Psr\\\\EventDispatcher\\\\EventDispatcherInterface, TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
+
+		-
 			message: "#^Cannot access property \\$code on DeepL\\\\Language\\|null\\.$#"
 			count: 7
 			path: ../../../Tests/Functional/Services/DeeplServiceTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Services\\\\LanguageServiceTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -311,6 +386,26 @@ parameters:
 			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$eventDispatcher of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects Psr\\\\EventDispatcher\\\\EventDispatcherInterface, TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 7 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Updates\\\\FormalityUpgradeWizardTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
@@ -359,3 +454,28 @@ parameters:
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Updates\\\\FormalityUpgradeWizardTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$eventDispatcher of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects Psr\\\\EventDispatcher\\\\EventDispatcherInterface, TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$coreCache of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Cache\\\\Frontend\\\\PhpFrontend\\|null, TYPO3\\\\CMS\\\\Core\\\\Site\\\\Set\\\\SetRegistry given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
+			message: "#^Call to method create\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\View\\\\ViewFactoryInterface\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\View\\\\ViewFactoryInterface not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+
+		-
+			message: "#^Instantiated class TYPO3\\\\CMS\\\\Core\\\\View\\\\ViewFactoryData not found\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Frontend\\\\Controller\\\\TypoScriptFrontendController\\:\\:getContext\\(\\)\\.$#"
+			count: 1
+			path: ../../../Classes/Event/Listener/RenderTranslatedFlagInFrontendPreviewMode.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Form\\\\Item\\\\SiteConfigSupportedLanguageItemsProcFunc\\:\\:getSupportedLanguageForField\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Classes/Form/Item/SiteConfigSupportedLanguageItemsProcFunc.php
@@ -106,6 +111,16 @@ parameters:
 			path: ../../../Tests/Functional/Fixtures/Frontend/PhpError.php
 
 		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration\\:\\:write\\(\\)\\.$#"
+			count: 2
+			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 3 parameters, 7 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Hooks\\\\TranslateHookTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
@@ -154,6 +169,21 @@ parameters:
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Hooks\\\\TranslateHookTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$siteSettingsFactory of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Hooks/TranslateHookTest.php
+
+		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration\\:\\:write\\(\\)\\.$#"
+			count: 2
+			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 3 parameters, 7 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\LocalizationInlineRegressionTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -206,6 +236,21 @@ parameters:
 			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$siteSettingsFactory of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+
+		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration\\:\\:write\\(\\)\\.$#"
+			count: 2
+			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 3 parameters, 7 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Regression\\\\PreviewTranslationInformationTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
@@ -256,9 +301,24 @@ parameters:
 			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$siteSettingsFactory of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Regression/PreviewTranslationInformationTest.php
+
+		-
 			message: "#^Cannot access property \\$code on DeepL\\\\Language\\|null\\.$#"
 			count: 7
 			path: ../../../Tests/Functional/Services/DeeplServiceTest.php
+
+		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration\\:\\:write\\(\\)\\.$#"
+			count: 2
+			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 3 parameters, 7 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Services\\\\LanguageServiceTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
@@ -311,6 +371,21 @@ parameters:
 			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
 
 		-
+			message: "#^Parameter \\#2 \\$siteSettingsFactory of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Services/LanguageServiceTest.php
+
+		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration\\:\\:write\\(\\)\\.$#"
+			count: 2
+			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
+			message: "#^Class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor invoked with 3 parameters, 7 required\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Updates\\\\FormalityUpgradeWizardTest\\:\\:buildDefaultLanguageConfiguration\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
@@ -359,3 +434,13 @@ parameters:
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Tests\\\\Functional\\\\Updates\\\\FormalityUpgradeWizardTest\\:\\:writeSiteConfiguration\\(\\) has parameter \\$site with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$siteSettingsFactory of class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteConfiguration constructor expects TYPO3\\\\CMS\\\\Core\\\\Site\\\\SiteSettingsFactory, Psr\\\\EventDispatcher\\\\EventDispatcherInterface given\\.$#"
+			count: 1
+			path: ../../../Tests/Functional/Updates/FormalityUpgradeWizardTest.php
+
+		-
+			message: "#^Call to an undefined method TYPO3\\\\CMS\\\\Core\\\\View\\\\ViewInterface\\:\\:getRenderingContext\\(\\)\\.$#"
+			count: 3
+			path: ../../../Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php

--- a/Classes/Event/Listener/RenderTranslatedFlagInFrontendPreviewMode.php
+++ b/Classes/Event/Listener/RenderTranslatedFlagInFrontendPreviewMode.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Event\Listener;
 
 use TYPO3\CMS\Core\Context\Context;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 use TYPO3\CMS\Frontend\Event\AfterCacheableContentIsGeneratedEvent;
 
@@ -18,7 +20,9 @@ final class RenderTranslatedFlagInFrontendPreviewMode
     public function __invoke(AfterCacheableContentIsGeneratedEvent $event): void
     {
         $controller = $this->getTypoScriptFrontendController($event);
-        $context = $controller->getContext();
+        $context = ((new Typo3Version())->getMajorVersion() >= 13)
+            ? GeneralUtility::makeInstance(Context::class)
+            : $controller->getContext();
         if (
             !$this->isInPreviewMode($context)
             || $this->processWorkspacePreview($context)

--- a/Classes/Upgrades/FormalityUpgradeWizard.php
+++ b/Classes/Upgrades/FormalityUpgradeWizard.php
@@ -8,7 +8,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 use TYPO3\CMS\Core\Configuration\SiteConfiguration;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\ChattyInterface;
@@ -48,7 +50,9 @@ class FormalityUpgradeWizard implements UpgradeWizardInterface, ChattyInterface
 
     public function executeUpdate(): bool
     {
-        $siteConfiguration = GeneralUtility::makeInstance(SiteConfiguration::class);
+        $siteConfiguration = (((new Typo3Version())->getMajorVersion() < 13)
+            ? GeneralUtility::makeInstance(SiteConfiguration::class)
+            : GeneralUtility::makeInstance(SiteWriter::class));
         $deeplService = GeneralUtility::makeInstance(DeeplService::class);
 
         $globalFormality = 'default';

--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -13,6 +13,7 @@ use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\Container;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\StringUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use WebVision\Deepltranslate\Core\Client;
@@ -124,6 +125,9 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
 
     protected function setUp(): void
     {
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            $this->coreExtensionsToLoad[] = 'typo3/cms-install';
+        }
         $this->EXAMPLE_LARGE_DOCUMENT_INPUT = str_repeat(AbstractDeepLTestCase::EXAMPLE_TEXT['en'] . PHP_EOL, 1000);
         $this->EXAMPLE_LARGE_DOCUMENT_OUTPUT = str_repeat(AbstractDeepLTestCase::EXAMPLE_TEXT['de'] . PHP_EOL, 1000);
         $this->serverUrl = getenv('DEEPL_SERVER_URL');

--- a/Tests/Functional/Hooks/TranslateHookTest.php
+++ b/Tests/Functional/Hooks/TranslateHookTest.php
@@ -6,12 +6,12 @@ namespace WebVision\Deepltranslate\Core\Tests\Functional\Hooks;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
 use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Hooks\TranslateHook;
@@ -153,7 +153,7 @@ final class TranslateHookTest extends AbstractDeepLTestCase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/BeUsersTranslateDeeplFlag.csv');
         $this->setUpBackendUser(2);
-        Bootstrap::initializeLanguageObject();
+        $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageServiceFactory::class)->createFromUserPreferences($GLOBALS['BE_USER']);
 
         $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
         $cmdMap = [

--- a/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
@@ -7,6 +7,7 @@ namespace WebVision\Deepltranslate\Core\Tests\Functional\ViewHelpers;
 use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
@@ -43,6 +44,14 @@ final class ExtensionActiveViewHelperTest extends FunctionalTestCase
     {
         self::$cache->flush();
         rmdir(self::$cachePath);
+    }
+
+    protected function setUp(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            $this->coreExtensionsToLoad[] = 'typo3/cms-install';
+        }
+        parent::setUp();
     }
 
     public static function renderDataProvider(): Generator

--- a/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
@@ -8,6 +8,9 @@ use Generator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
 use TYPO3\CMS\Fluid\View\TemplateView;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 use TYPO3Fluid\Fluid\Core\Cache\FluidCacheInterface;
@@ -87,11 +90,18 @@ final class ExtensionActiveViewHelperTest extends FunctionalTestCase
     #[Test]
     public function render(string $template, array $variables, string $expected): void
     {
-        $view = new TemplateView();
+        if ((new Typo3Version())->getMajorVersion() < 13) {
+            $view = new TemplateView();
+            $view->getRenderingContext()->getViewHelperResolver()->addNamespace('deepl', 'WebVision\\Deepltranslate\\Core\\ViewHelpers');
+            $view->getRenderingContext()->setCache(self::$cache);
+            $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        } else {
+            $view = GeneralUtility::makeInstance(ViewFactoryInterface::class)->create(new ViewFactoryData());
+            $view->getRenderingContext()->getViewHelperResolver()->addNamespace('deepl', 'WebVision\\Deepltranslate\\Core\\ViewHelpers');
+            $view->getRenderingContext()->setCache(self::$cache);
+            $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
+        }
         $view->assignMultiple($variables);
-        $view->getRenderingContext()->getViewHelperResolver()->addNamespace('deepl', 'WebVision\\Deepltranslate\\Core\\ViewHelpers');
-        $view->getRenderingContext()->setCache(self::$cache);
-        $view->getRenderingContext()->getTemplatePaths()->setTemplateSource($template);
         static::assertSame($expected, $view->render());
     }
 }


### PR DESCRIPTION
- **[TASK] Add `typo3/cms-install` as `$coreExtensionToLoad`**
  Since TYPO3 v13 the `typo3/cms-install` extension is optional
  and typo3/testing-framework no longer defines it as extension
  to load (core) in functional tests.
  
  `web-vision/deepltranslate-core` requires it for now to ensure
  that upgrade wizards can be executed - an oversight from TYPO3
  core team.
  

- **[TASK] Add dual TYPO3 version support for `SiteBasedTestTrait`**
  The `SiteBasedTestTrait` takes care to write site configuration
  in functional tests and TYPO3 v13 changed the logic of writing
  it. Due to changed structure and the additional SiteSettings
  support functional tests failing now with TYPO3 v13.
  
  This change adopts required changed for the SiteBasedTestTrait
  while keeping TYPO3 v12 support intact.
  

- **[TASK] Use suitable siteconfig writer class in FormalityUpgradeWizard**
  This change ensures to use the suiting site configuration writer
  class depending on the TYYPO3 version which has changed between
  TYPO3 v12 and v13.
  

- **[TASK] Avoid removed `Bootstrap::initializeLanguageObject()` call**
  The `Bootstrap::initializeLanguageObject()` has been removed in
  TYPO3 v13 and is now replaced to ensure working test over all
  supported TYPO3 core versions.
  

- **[TASK] Mitigate removed `TSFE->getContext()` method in `RenderTranslatedFlagInFrontendPreviewMode`**
  TYPO3 removed quite some method of `TSFE` internal or removed them,
  one of them `getContext()` can be mitigated easily.
  
  This change retrieves the context either from TSFE or uses the
  `GeneralUtility::makeInstance()` to retrieve it within the
  `RenderTranslatedFlagInFrontendPreviewMode` PSR-14 event listener.
  

- **[TASK] Mitigate deprecated fluid TemplateView in favour of ViewFactoryInterface**
  Since TYPO3 v13 directly instantiating a concrete view has been
  replaced with a more generic `ViewFactoryInterface` along with
  default fluid template based variant.
  
  To keep functional tests hard as possible we need to work around
  the deprecation with TYPO3 v13 by using a version check in the
  ViewHelper related functional tests to use either the factory or
  the old way for dual TYPO3 version compatibility.
  
  [1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.3/Feature-104773-GenericViewFactory.html
  
- **[TASK] Add TYPO3 v13 code phpstan errors for TYPO3v12 to baseline**
  PHPStan does not understand or respect TYPO3
  version conditional based code to make code
  flows based on the TYPO3 version, which leads
  to false-positive error reportings.

  Until a better solution can be provided, we need
  to add them to the depending phpstan baseline file.

  Used command(s):

  ```bash
  Build/Scripts/runTests.sh -t 12 -p 8.2 -s composerUpdate
  Build/Scripts/runTests.sh -t 12 -p 8.2 -s phpstanGenerateBaseline
  Build/Scripts/runTests.sh -t 13 -p 8.2 -s composerUpdate
  Build/Scripts/runTests.sh -t 13 -p 8.2 -s phpstanGenerateBaseline
  ```