### PR TITLE
[TASK] Use custom DataHandler command instead of invalid cmdMap

### DIFF
--- a/Classes/Override/LocalizationController.php
+++ b/Classes/Override/LocalizationController.php
@@ -82,13 +82,13 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
      */
     protected function process($params): void
     {
+        $deeplTranslateActions = [static::ACTION_LOCALIZEDEEPL, static::ACTION_LOCALIZEDEEPL_AUTO];
         $destLanguageId = (int)$params['destLanguageId'];
 
         // Build command map
         $cmd = [
             'tt_content' => [],
         ];
-
         if (isset($params['uidList']) && is_array($params['uidList'])) {
             foreach ($params['uidList'] as $currentUid) {
                 if (
@@ -96,17 +96,10 @@ class LocalizationController extends \TYPO3\CMS\Backend\Controller\Page\Localiza
                     || $params['action'] === static::ACTION_LOCALIZEDEEPL
                     || $params['action'] === static::ACTION_LOCALIZEDEEPL_AUTO
                 ) {
+                    $dataHandlerCommandName = (in_array($params['action'], $deeplTranslateActions, true) ? 'deepltranslate' : 'localize');
                     $cmd['tt_content'][$currentUid] = [
-                        'localize' => $destLanguageId,
+                        $dataHandlerCommandName => $destLanguageId,
                     ];
-                    //setting mode and source language for deepl translate.
-                    if (
-                        $params['action'] === static::ACTION_LOCALIZEDEEPL
-                        || $params['action'] === static::ACTION_LOCALIZEDEEPL_AUTO
-                    ) {
-                        $cmd['localization']['custom']['mode']          = 'deepl';
-                        $cmd['localization']['custom']['srcLanguageId'] = $params['srcLanguageId'];
-                    }
                 } else {
                     $cmd['tt_content'][$currentUid] = [
                         'copyToLanguage' => $destLanguageId,

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -83,8 +83,9 @@ final class DeeplBackendUtility
         );
         $params = [];
         $params['redirect'] = $redirectUrl;
-        $params['cmd'][$table][$id]['localize'] = $lUid_OnPage;
-        $params['cmd']['localization']['custom']['mode'] = 'deepl';
+        //$params['cmd'][$table][$id]['localize'] = $lUid_OnPage;
+        //$params['cmd']['localization']['custom']['mode'] = 'deepl';
+        $params['cmd'][$table][$id]['deepltranslate'] = $lUid_OnPage;
         $href = self::buildBackendRoute('tce_db', $params);
         $title =
             (string)LocalizationUtility::translate(

--- a/Tests/Functional/Hooks/TranslateHookTest.php
+++ b/Tests/Functional/Hooks/TranslateHookTest.php
@@ -159,12 +159,7 @@ final class TranslateHookTest extends AbstractDeepLTestCase
         $cmdMap = [
             'tt_content' => [
                 1 => [
-                    'localize' => 2,
-                ],
-            ],
-            'localization' => [
-                'custom' => [
-                    'mode' => 'deepl',
+                    'deepltranslate' => 2,
                 ],
             ],
         ];

--- a/Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+++ b/Tests/Functional/Regression/LocalizationInlineRegressionTest.php
@@ -93,14 +93,9 @@ final class LocalizationInlineRegressionTest extends AbstractDeepLTestCase
     public function ensureInlineElementsTranslationOnLocalization(): void
     {
         $commandMap = [
-            'localization' => [
-                'custom' => [
-                    'mode' => 'deepl',
-                ],
-            ],
             'pages' => [
                 1 => [
-                    'localize' => 1,
+                    'deepltranslate' => 1,
                 ],
             ],
         ];


### PR DESCRIPTION
Until now the DataHandler command map array has been misused
to transport custom `localize` command options relevant for
translation with DeepL, processed with a hook implementation
and using the original command.

TYPO3 v13 hardens the DataHandler even further, which is a
really good thing, and breaking fingers of developers mess
with the data monster - and loosing [1].

This change switch to a custom DataHandler command and using
the hook to handle the command directly by using the public
`DataHandler->localize()` method to mitigate the TYPO3 v13
exception thrown by `DataHandler->start()`.

Tests and link creation are aligned to use the new command
name and omit abitary and invalid options.

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/83073
