### PR TITLE
[TASK] Update `deeplcom/deepl-php:^1.10.1`

### DIFF
--- a/.github/workflows/testcore12.yml
+++ b/.github/workflows/testcore12.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.1', '8.2', '8.3' ]
+        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
     permissions:
       # actions: read|write|none
       actions: none

--- a/.github/workflows/testcore13.yml
+++ b/.github/workflows/testcore13.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '8.2', '8.3' ]
+        php-version: [ '8.2', '8.3', '8.4' ]
     permissions:
       # actions: read|write|none
       actions: none

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-pdo": "*",
-		"deeplcom/deepl-php": ">=1.6.0 <=1.8.0",
+		"deeplcom/deepl-php": "^1.10.1",
 		"typo3/cms-backend": "^12.4.2 || ^13.4",
 		"typo3/cms-core": "^12.4.2 || ^13.4",
 		"typo3/cms-extbase": "^12.4.2 || ^13.4",


### PR DESCRIPTION
This change updates the version of the used
third party dependency to support PHP8.4 out
of the box and align with TYPO3 v12 and v13
support.

Tests are now also executed with PHP 8.4.

Used command(s):

```shell
composer require --no-update \
    "deeplcom/deepl-php":"^1.10.1"
```
