### PR TITLE
[TASK] Redefine composer dependencies

### DIFF
--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -104,7 +104,6 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
      */
     protected array $coreExtensionsToLoad = [
         'typo3/cms-setup',
-        'typo3/cms-scheduler',
     ];
 
     /**

--- a/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ExtensionActiveViewHelperTest.php
@@ -22,7 +22,6 @@ final class ExtensionActiveViewHelperTest extends FunctionalTestCase
 
     protected array $coreExtensionsToLoad = [
         'typo3/cms-setup',
-        'typo3/cms-scheduler',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,6 @@
 		"typo3/cms-core": "^12.4.2 || ^13.4",
 		"typo3/cms-extbase": "^12.4.2 || ^13.4",
 		"typo3/cms-fluid": "^12.4.2 || ^13.4",
-		"typo3/cms-install": "^12.4.2 || ^13.4",
 		"typo3/cms-setup": "^12.4.2 || ^13.4"
 	},
 	"require-dev": {
@@ -104,6 +103,7 @@
 		"typo3/cms-fluid-styled-content": "^12.4.2 || ^13.4",
 		"typo3/cms-frontend": "^12.4.2 || ^13.4",
 		"typo3/cms-info": "^12.4.2 || ^13.4",
+		"typo3/cms-install": "^12.4.2 || ^13.4",
 		"typo3/cms-lowlevel": "^12.4.2 || ^13.4",
 		"typo3/cms-rte-ckeditor": "^12.4.2 || ^13.4",
 		"typo3/cms-styleguide": "^12.0.5 || ^13.4",
@@ -116,7 +116,9 @@
         "b13/container": "Just to be loaded after EXT:container",
 		"web-vision/enable-translated-content": "Adds enable translated content button to language columns in page view",
 		"web-vision/deepltranslate-assets": "Enables the translation of files in FileList Modal via deepl",
-		"typo3/cms-dashboard": "Install the package to enable the widgets from deepltranslate packages"
+		"typo3/cms-dashboard": "Install the package to enable the widgets from deepltranslate packages",
+		"typo3/cms-install": "Install the package to run DeepL translate related upgrade wizards",
+		"web-vision/deepltranslate-glossary": "TYPO3 powered glossary for DeepL Translate. Manage your glossary for optimized translations"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,6 @@
 		"typo3/cms-extbase": "^12.4.2 || ^13.4",
 		"typo3/cms-fluid": "^12.4.2 || ^13.4",
 		"typo3/cms-install": "^12.4.2 || ^13.4",
-		"typo3/cms-scheduler": "^12.4.2 || ^13.4",
 		"typo3/cms-setup": "^12.4.2 || ^13.4"
 	},
 	"require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -18,7 +18,6 @@ $EM_CONF[$_EXTKEY] = [
             'fluid' => '12.4.0-13.4.99',
             'install' => '12.4.0-13.4.99',
             'setup' => '12.4.0-13.4.99',
-            'scheduler' => '12.4.0-13.4.99',
         ],
         'conflicts' => [
             'recordlist_thumbnail' => '*',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,6 @@ $EM_CONF[$_EXTKEY] = [
             'backend' => '12.4.0-13.4.99',
             'extbase' => '12.4.0-13.4.99',
             'fluid' => '12.4.0-13.4.99',
-            'install' => '12.4.0-13.4.99',
             'setup' => '12.4.0-13.4.99',
         ],
         'conflicts' => [
@@ -26,8 +25,10 @@ $EM_CONF[$_EXTKEY] = [
         'suggests' => [
             'container' => '*',
             'dashboard' => '*',
+            'install' => '*',
             'enable_translated_content' => '*',
             'deepltranslate_assets' => '*',
+            'deepltranslate_glossary' => '*',
         ],
     ],
     'autoload' => [


### PR DESCRIPTION
Adjust updates on required dependencies to deepltranslate-core after extracting glossary to an on add-on extension

* `typo3/cms-scheduler` is not mandantory for the core extension and is removed. Dependency (soft) of extracted `web-vision/deepltranslate-glossary`
* `typo3/cms-install` is optional since TYPO3 v13 and is removed as hard dependency. Readded as development dependy for functional tests. Added as suggestion as otherwise upgrade wizards are not executable which makes updates nearly impossible.