### PR TITLE
[TASK]  Define classic mode autoloader in `ext_emconf.php` for depending and shipped packages

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -34,6 +34,8 @@ $EM_CONF[$_EXTKEY] = [
     'autoload' => [
         'psr-4' => [
             'WebVision\\Deepltranslate\\Core\\' => 'Classes',
+            'DeepL\\' => 'vendor/deeplcom/deepl-php/src',
+            'Http\\Discovery\\' => 'vendor/php-http/discovery/src',
         ],
     ],
 ];


### PR DESCRIPTION
For classic mode instances, the system ships self-installed packages
for `DeepL` and `Http\Discovery\`.

As composer-based installations ignore autoloading in `ext_emconf.php`,
this can be safely added to ensure external dependencies installed during
release will work out of the box.