### PR TITLE
[BUGFIX] Avoid PHP warning when query parameter "id" is missing

### DIFF
--- a/Classes/Event/Listener/RenderLocalizationSelect.php
+++ b/Classes/Event/Listener/RenderLocalizationSelect.php
@@ -30,7 +30,7 @@ final class RenderLocalizationSelect
         /** @var Site $site */
         $site = $request->getAttribute('site');
         $siteLanguages = $site->getLanguages();
-        $options = $this->generator->buildTranslateDropdownOptions($siteLanguages, (int)$request->getQueryParams()['id'], $request->getUri());
+        $options = $this->generator->buildTranslateDropdownOptions($siteLanguages, (int)($request->getQueryParams()['id'] ?? 0), $request->getUri());
         if ($options !== '') {
             $additionalHeader = '<div class="form-row">'
                 . '<div class="form-group">'


### PR DESCRIPTION
This error occurs directly after opening the backend when the page module is the default module: https://example.org/typo3/module/web/

![Screenshot 2025-01-10 154441](https://github.com/user-attachments/assets/ca276a0d-f3e8-47c0-a194-373675f445fd)
