### PR TITLE
[TASK] Remove obsolete f:replace from partial

### DIFF
--- a/Classes/Form/TranslationDropdownGenerator.php
+++ b/Classes/Form/TranslationDropdownGenerator.php
@@ -91,8 +91,6 @@ final class TranslationDropdownGenerator
                 $redirectUrl = DeeplBackendUtility::buildBackendRoute('record_edit', $parameters);
                 $params = [];
                 $params['redirect'] = $redirectUrl;
-                //$params['cmd']['pages'][$id]['localize'] = $languageUid;
-                //$params['cmd']['localization']['custom']['mode'] = 'deepl';
                 $params['cmd']['pages'][$id]['deepltranslate'] = $languageUid;
                 $targetUrl = DeeplBackendUtility::buildBackendRoute('tce_db', $params);
                 $output .= '<option value="' . htmlspecialchars($targetUrl) . '">' . htmlspecialchars($languageTitle) . '</option>';

--- a/Classes/ViewHelpers/DeeplTranslateViewHelper.php
+++ b/Classes/ViewHelpers/DeeplTranslateViewHelper.php
@@ -69,7 +69,7 @@ final class DeeplTranslateViewHelper extends AbstractViewHelper
             $redirectUrl = DeeplBackendUtility::buildBackendRoute('record_edit', $parameters);
             $params = [];
             $params['redirect'] = $redirectUrl;
-            $params['cmd']['pages'][$context->getPageId()]['localize'] = $languageMatch[$possibleLanguage];
+            $params['cmd']['pages'][$context->getPageId()]['deepltranslate'] = $languageMatch[$possibleLanguage];
 
             $targetUrl = DeeplBackendUtility::buildBackendRoute('tce_db', $params);
 

--- a/Resources/Private/Backend/Partials/AdditionalTranslation/DeeplDefault.html
+++ b/Resources/Private/Backend/Partials/AdditionalTranslation/DeeplDefault.html
@@ -23,7 +23,7 @@
                             <select class="form-select" name="createNewLanguage" data-global-event="change" data-action-navigate="$value">
                                 <option><f:translate key="backend.label" extensionName="deepltranslate_core" /></option>
                                 <f:for each="{deeplLanguages}" as="languageName" key="url">
-                                    <option value="{url -> f:replace(search: '%5Blocalize%5D=', replace: '%5Bdeepltranslate%5D=')}">{languageName}</option>
+                                    <option value="{url}">{languageName}</option>
                                 </f:for>
                             </select>
                         </div>


### PR DESCRIPTION
Recently merged pull-request #429 to solve page
settings translation provided two changes which
fixes the same issue in two different ways by
providing the correct DataHandler command name
in the url.

Only one is needed and allows to drop the not
so nice `f:replace()` ViewHelper usage within
the partial and keeping the working state.

Replace ViewHelper is now removed again and
minor code cleanup (outcommented code) done
in the same step.

Related: #429 (#428) da13ab1cae106bd70892a2db9587d89af8d912a7