### PR TITLE
[BUGFIX] Add support for nested `EXT:gridelements`

### DIFF
--- a/Build/phpstan/Core12/classAliasses.php
+++ b/Build/phpstan/Core12/classAliasses.php
@@ -1,0 +1,4 @@
+<?php
+
+// avoiding phpstan errors, as extension is not loaded and therefore not in DI list
+class_alias('TYPO3\\CMS\\Backend\\RecordList\\DatabaseRecordList', 'GridElementsTeam\\Gridelements\\Xclass\\DatabaseRecordList');

--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -26,9 +26,14 @@ parameters:
 			path: ../../../Classes/Override/CommandMapPostProcessingHook.php
 
 		-
-			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\Core12\\\\DatabaseRecordList\\:\\:makeLocalizationPanel\\(\\) has parameter \\$translations with no value type specified in iterable type array\\.$#"
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\Core12\\\\DatabaseRecordListCore\\:\\:makeLocalizationPanel\\(\\) has parameter \\$translations with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../../../Classes/Override/Core12/DatabaseRecordList.php
+			path: ../../../Classes/Override/Core12/DatabaseRecordListCore.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\Core12\\\\DatabaseRecordListWithGridelements\\:\\:makeLocalizationPanel\\(\\) has parameter \\$translations with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Classes/Override/Core12/DatabaseRecordListWithGridelements.php
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\LocalizationController\\:\\:process\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"

--- a/Build/phpstan/Core12/phpstan.neon
+++ b/Build/phpstan/Core12/phpstan.neon
@@ -1,25 +1,26 @@
 includes:
-  - ../../../.Build/vendor/saschaegerer/phpstan-typo3/extension.neon
-  - phpstan-baseline.neon
+	- ../../../.Build/vendor/saschaegerer/phpstan-typo3/extension.neon
+	- phpstan-baseline.neon
 
 parameters:
-  # Use local .cache dir instead of /tmp
-  tmpDir: ../../../.cache/phpstan
+	# Use local .cache dir instead of /tmp
+	tmpDir: ../../../.cache/phpstan
+	level: 8
 
-  level: 8
+	paths:
+		- ../../../Classes/
+		- ../../../Tests/
 
-  paths:
-    - ../../../Classes/
-    - ../../../Tests/
+	excludePaths:
+		- ../../../.Build/*
+		- ../../../Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_emconf.php
+		- ../../../Tests/Functional/Fixtures/Extensions/test_services_override/ext_emconf.php
+		- ../../../Tests/Functional/Fixtures/Extensions/testing_framework_backenduserhandler_replacement/ext_emconf.php
+	bootstrapFiles:
+		- classAliasses.php
 
-  excludePaths:
-    - ../../../.Build/*
-    - ../../../Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_emconf.php
-    - ../../../Tests/Functional/Fixtures/Extensions/test_services_override/ext_emconf.php
-    - ../../../Tests/Functional/Fixtures/Extensions/testing_framework_backenduserhandler_replacement/ext_emconf.php
-
-  typo3:
-    contextApiGetAspectMapping:
-      'frontend.preview': TYPO3\CMS\Frontend\Aspect\PreviewAspect
-    requestGetAttributeMapping:
-      'typo3.testing.context': TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext
+	typo3:
+		contextApiGetAspectMapping:
+			'frontend.preview': TYPO3\CMS\Frontend\Aspect\PreviewAspect
+		requestGetAttributeMapping:
+			'typo3.testing.context': TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequestContext

--- a/Build/phpstan/Core13/classAliasses.php
+++ b/Build/phpstan/Core13/classAliasses.php
@@ -1,0 +1,4 @@
+<?php
+
+// avoiding phpstan errors, as extension is not loaded and therefore not in DI list
+class_alias('TYPO3\\CMS\\Backend\\RecordList\\DatabaseRecordList', 'GridElementsTeam\\Gridelements\\Xclass\\DatabaseRecordList');

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -31,9 +31,14 @@ parameters:
 			path: ../../../Classes/Override/CommandMapPostProcessingHook.php
 
 		-
-			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\Core12\\\\DatabaseRecordList\\:\\:makeLocalizationPanel\\(\\) has parameter \\$translations with no value type specified in iterable type array\\.$#"
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\Core12\\\\DatabaseRecordListCore\\:\\:makeLocalizationPanel\\(\\) has parameter \\$translations with no value type specified in iterable type array\\.$#"
 			count: 1
-			path: ../../../Classes/Override/Core12/DatabaseRecordList.php
+			path: ../../../Classes/Override/Core12/DatabaseRecordListCore.php
+
+		-
+			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\Core12\\\\DatabaseRecordListWithGridelements\\:\\:makeLocalizationPanel\\(\\) has parameter \\$translations with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: ../../../Classes/Override/Core12/DatabaseRecordListWithGridelements.php
 
 		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Override\\\\LocalizationController\\:\\:process\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"

--- a/Build/phpstan/Core13/phpstan.neon
+++ b/Build/phpstan/Core13/phpstan.neon
@@ -17,7 +17,8 @@ parameters:
     - ../../../Tests/Functional/Updates/Fixtures/Extension/test_extension/ext_emconf.php
     - ../../../Tests/Functional/Fixtures/Extensions/test_services_override/ext_emconf.php
     - ../../../Tests/Functional/Fixtures/Extensions/testing_framework_backenduserhandler_replacement/ext_emconf.php
-
+  bootstrapFiles:
+    - classAliasses.php
   typo3:
     contextApiGetAspectMapping:
       'frontend.preview': TYPO3\CMS\Frontend\Aspect\PreviewAspect

--- a/Classes/Override/Core12/DatabaseRecordList.php
+++ b/Classes/Override/Core12/DatabaseRecordList.php
@@ -14,7 +14,7 @@ use WebVision\Deepltranslate\Core\Utility\DeeplBackendUtility;
  * @internal
  * @override
  */
-class DatabaseRecordList extends \TYPO3\CMS\Backend\RecordList\DatabaseRecordList
+trait DatabaseRecordList
 {
     /**
      * Creates the localization panel

--- a/Classes/Override/Core12/DatabaseRecordListCore.php
+++ b/Classes/Override/Core12/DatabaseRecordListCore.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Override\Core12;
+
+class DatabaseRecordListCore extends \TYPO3\CMS\Backend\RecordList\DatabaseRecordList
+{
+    use DatabaseRecordList;
+}

--- a/Classes/Override/Core12/DatabaseRecordListWithGridelements.php
+++ b/Classes/Override/Core12/DatabaseRecordListWithGridelements.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\Deepltranslate\Core\Override\Core12;
+
+class DatabaseRecordListWithGridelements extends \GridElementsTeam\Gridelements\Xclass\DatabaseRecordList
+{
+    use DatabaseRecordList;
+}

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,8 @@
 		"web-vision/deepltranslate-assets": "Enables the translation of files in FileList Modal via deepl",
 		"typo3/cms-dashboard": "Install the package to enable the widgets from deepltranslate packages",
 		"typo3/cms-install": "Install the package to run DeepL translate related upgrade wizards",
-		"web-vision/deepltranslate-glossary": "TYPO3 powered glossary for DeepL Translate. Manage your glossary for optimized translations"
+		"web-vision/deepltranslate-glossary": "TYPO3 powered glossary for DeepL Translate. Manage your glossary for optimized translations",
+		"gridelementsteam/gridelements": "This suggest is only for load order adjusting issues with gridelements"
 	},
 	"autoload": {
 		"psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -29,6 +29,7 @@ $EM_CONF[$_EXTKEY] = [
             'enable_translated_content' => '*',
             'deepltranslate_assets' => '*',
             'deepltranslate_glossary' => '*',
+            'gridelements' => '*',
         ],
     ],
     // @todo Autoload section in `ext_emconf.php` should not be needed anymore since TYPO3 v12, and in first test it

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -29,9 +29,15 @@ defined('TYPO3') or die();
     ];
 
     //xclass databaserecordlist for rendering custom checkboxes to toggle deepl selection in recordlist
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Backend\RecordList\DatabaseRecordList::class] = [
-        'className' => \WebVision\Deepltranslate\Core\Override\Core12\DatabaseRecordList::class,
-    ];
+    if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('gridelements') && !empty($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['gridelements']['nestingInListModule'])) {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Backend\RecordList\DatabaseRecordList::class] = [
+            'className' => \WebVision\Deepltranslate\Core\Override\Core12\DatabaseRecordListWithGridelements::class,
+        ];
+    } else {
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][\TYPO3\CMS\Backend\RecordList\DatabaseRecordList::class] = [
+            'className' => \WebVision\Deepltranslate\Core\Override\Core12\DatabaseRecordListCore::class,
+        ];
+    }
 
     if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         //xclass CommandMapPostProcessingHook for translating contents within containers


### PR DESCRIPTION
With `gridelements` installed the extension internal override of the
DatabaseRecordList won't work anymore, as `gridelements` overrides the
same way.

This commit adjusts the implementation by overriding the respective
class depending on the installed `gridelements` extension and respecting
the setting if the nested content element support is enabled.

As `gridelements` has no public available repository for TYPO3 13,
assume this workflow works in 13.