### PR TITLE
[TASK] Minor streamlining of publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,7 @@ jobs:
         id: get-comment
         run: |
           readonly local releaseCommentPrependBody="$( git tag -l ${{ env.version }} --format '%(contents)' )"
-
-          if [[ -n "${releaseCommentPrependBody// }" ]]; then
+          if (( $(grep -c . <<<"${releaseCommentPrependBody// }") > 1 )); then
             {
               echo 'releaseCommentPrependBody<<EOF'
               echo "$releaseCommentPrependBody"
@@ -43,11 +42,9 @@ jobs:
           fi
           {
             echo 'terReleaseNotes<<EOF'
-            echo "[RELEASE] ${{ env.version }}"
-            echo "Notes: https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
             echo EOF
           } >> "$GITHUB_ENV"
-          echo "DETECTED_EXTENSION_KEY=$(cat composer.json | jq -r '.extra."typo3/cms"."extension-key"' )" >> "$GITHUB_ENV"
 
       - name: Setup PHP 7.4 ( wv_deepltranslate 4.x )
         if: github.event.base_ref == 'refs/heads/4'


### PR DESCRIPTION
This change streamlines the publish GitHub
workflow slightly adopting latest changes
in other projects.

* Only add GitHub release body prepanding based
  git tag when more than one line.
* Only push the github release link as tailor
  upload comment.
