### PR TITLE
[TASK] Add unsupported private addon versions as conflict

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,11 @@ jobs:
         id: get-version
         run: echo "version=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
+      - name: Get extension key
+        id: get-extension-key
+        run: |
+          echo "DETECTED_EXTENSION_KEY=$(cat composer.json | jq -r '.extra."typo3/cms"."extension-key"' )" >> "$GITHUB_ENV"
+
       - name: Get comment
         id: get-comment
         run: |
@@ -45,21 +50,11 @@ jobs:
             echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
             echo EOF
           } >> "$GITHUB_ENV"
-          echo "DETECTED_EXTENSION_KEY=$(cat composer.json | jq -r '.extra."typo3/cms"."extension-key"' )" >> "$GITHUB_ENV"
 
       - name: Setup PHP 7.4 ( wv_deepltranslate 4.x )
-        if: github.event.base_ref == 'refs/heads/4'
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
-          extensions: intl, mbstring, json, zip, curl
-          tools: composer:v2
-
-      - name: Setup PHP 8.1 ( deepltranlsate-core 5.x )
-        if: github.event.base_ref == 'refs/heads/main'
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.1
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 
@@ -114,13 +109,7 @@ jobs:
             LICENSE
           fail_on_unmatched_files: true
 
-      # @todo Currently an issue exists with the TYPO3 Extension Repository (TER) tailor based uploads, which seems to
-      #       be WAF related and the T3O TER Team working on. Allow this step to fail (continue on error) for now until
-      #       issues has been sorted out.
-      #       https://github.com/TYPO3/tailor/issues/82
       - name: Publish to TER
-        # @todo Remove `continue-on-error` after upload with tailor has been fixed.
-        continue-on-error: true
         run: |
           php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.terReleaseNotes }}" ${{ env.version }} \
             --artefact=tailor-version-artefact/${{ env.DETECTED_EXTENSION_KEY }}_${{ env.version }}.zip

--- a/composer.json
+++ b/composer.json
@@ -1,149 +1,140 @@
 {
-	"name": "web-vision/wv_deepltranslate",
-	"type": "typo3-cms-extension",
-	"description": "This extension provides option to translate content element, and TCA record texts to DeepL supported languages using DeepL API services with TYPO3 CMS",
-	"license": ["GPL-2.0-or-later"],
-	"homepage": "https://www.web-vision.de/en/automated-translations-with-typo3-and-deepl.html",
-	"minimum-stability": "beta",
-	"prefer-stable": true,
-	"keywords": [
-		"TYPO3 CMS",
-		"extension",
-		"translate",
-		"deepl",
-		"googletranslate"
-	],
-	"authors": [
-		{
-			"name": "web-vision GmbH",
-			"email": "hello@web-vision.de",
-			"role": "Maintainer"
-		},
-		{
-			"name": "Mark Houben",
-			"email": "markhouben91@gmail.com",
-			"role": "Developer"
-		},
-		{
-			"name": "Markus Hofmann",
-			"email": "typo3@calien.de",
-			"role": "Developer"
-		},
-		{
-			"name": "Riad Zejnilagic Trumic",
-			"role": "Developer"
-		}
-	],
-	"support": {
-		"issues": "https://github.com/web-vision/wv_deepltranslate/issues",
-		"source": "https://github.com/web-vision/wv_deepltranslate"
-	},
-	"conflict": {
-		"studiomitte/recordlist-thumbnail": "*",
-		"webvision/deepltranslate-core": "*"
-	},
-	"config": {
-		"vendor-dir": ".Build/vendor",
-		"bin-dir": ".Build/bin",
-		"optimize-autoloader": true,
-		"sort-packages": true,
-		"allow-plugins": {
-			"typo3/class-alias-loader": true,
-			"typo3/cms-composer-installers": true,
-			"helhum/typo3-console-plugin": true,
-			"php-http/discovery": true
-		}
-	},
-	"extra": {
-		"typo3/cms": {
-			"cms-package-dir": "{$vendor-dir}/typo3/cms",
-			"extension-key": "wv_deepltranslate",
-			"ignore-as-root": false,
-			"web-dir": ".Build/Web",
-			"app-dir": ".Build"
-		},
-		"branch-alias": {
-			"dev-4": "4.x.x-dev"
-		}
-	},
-	"require": {
-		"php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3",
-		"ext-curl": "*",
-		"ext-json": "*",
-		"ext-pdo": "*",
-		"deeplcom/deepl-php": ">=1.6.0 <=1.8.0",
-		"typo3/cms-backend": "^11.5 || ^12.4",
-		"typo3/cms-core": "^11.5 || ^12.4",
-		"typo3/cms-extbase": "^11.5 || ^12.4",
-		"typo3/cms-fluid": "^11.5 || ^12.4",
-		"typo3/cms-install": "^11.5 || ^12.4",
-		"typo3/cms-setup": "^11.5 || ^12.4",
-		"typo3/cms-scheduler": "^11.5 || ^12.4"
-	},
-	"require-dev": {
-		"b13/container": "^2.2",
-		"friendsofphp/php-cs-fixer": "^3.41",
-		"helhum/typo3-console": "^7.1.6 || ^8.0.2",
-		"helmich/phpunit-json-assert": "^3.4.3 || ^3.5.1",
-		"helmich/typo3-typoscript-lint": "^3.1.0",
-		"nikic/php-parser": "^4.15.1",
-		"php-mock/php-mock-phpunit": "^2.6",
-		"phpstan/phpstan": "^1.10",
-		"phpunit/phpunit": "^9.6.8 || ^10.1",
-		"ramsey/uuid": "^4.2",
-		"saschaegerer/phpstan-typo3": "^1.9",
-		"sbuerk/typo3-styleguide-selector": "^11.5.5 || ^12.0.5",
-		"typo3/cms-belog": "^11.5 || ^12.4",
-		"typo3/cms-dashboard": "^11.5 || ^12.4",
-		"typo3/cms-extensionmanager": "^11.5 || ^12.4",
-		"typo3/cms-filelist": "^11.5 || ^12.4",
-		"typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
-		"typo3/cms-frontend": "^11.5 || ^12.4",
-		"typo3/cms-info": "^11.5 || ^12.4",
-		"typo3/cms-lowlevel": "^11.5 || ^12.4",
-		"typo3/cms-rte-ckeditor": "^11.5 || ^12.4",
-		"typo3/cms-styleguide": "^11 || ^12",
-		"typo3/cms-tstemplate": "^11.5 || ^12.4",
-		"typo3/cms-workspaces": "^11.5 || ^12.4",
-		"typo3/testing-framework": "^7.0"
-	},
-	"suggest": {
-        "b13/container": "Just to be loaded after EXT:container",
-		"web-vision/enable-translated-content": "Adds enable translated content button to language columns in page view",
-		"web-vision/deepltranslate-assets": "Enables the translation of files in FileList Modal via deepl",
-		"typo3/cms-dashboard": "Install the package to enable the widgets from deepltranslate packages"
-	},
-	"autoload": {
-		"psr-4": {
-			"WebVision\\WvDeepltranslate\\": "Classes"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"WebVision\\WvDeepltranslate\\Tests\\": "Tests"
-		}
-	},
-	"scripts": {
-		"cs": ".Build/bin/php-cs-fixer",
-		"tl": ".Build/bin/typoscript-lint",
-		"phpstan": ".Build/bin/phpstan",
-		"phpunit": ".Build/bin/phpunit",
-		"cs:check": "@cs fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
-		"cs:fix": "@cs fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
-		"analyze:php": "@phpstan analyse --ansi --no-progress --memory-limit=768M",
-		"analyze:php:11": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon",
-		"analyze:baseline:11": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core11/phpstan-baseline.neon",
-		"analyze:php:12": "@analyze:php --configuration=Build/phpstan/Core12/phpstan.neon",
-		"analyze:baseline:12": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core12/phpstan-baseline.neon",
-		"lint:typoscript": "@tl --ansi --config=./Build/typoscript-lint/typoscript-lint.yml",
-		"lint:php": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
-		"test:php": [
-			"@test:php:unit",
-			"@test:php:functional"
-		],
-		"test:php:unit": "@phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
-		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml",
-		"test:php:unit10": "@phpunit --colors=always --configuration Build/phpunit/UnitTests-10.xml",
-		"test:php:functional10": "@test:php:unit --configuration Build/phpunit/FunctionalTests-10.xml"
-	}
+  "name": "web-vision/wv_deepltranslate",
+  "type": "typo3-cms-extension",
+  "description": "This extension provides option to translate content element, and TCA record texts to DeepL supported languages using DeepL API services with TYPO3 CMS",
+  "license": [
+    "GPL-2.0-or-later"
+  ],
+  "homepage": "https://www.web-vision.de/en/automated-translations-with-typo3-and-deepl.html",
+  "minimum-stability": "beta",
+  "prefer-stable": true,
+  "keywords": [
+    "TYPO3 CMS",
+    "extension",
+    "translate",
+    "deepl",
+    "googletranslate"
+  ],
+  "authors": [
+    {
+      "name": "web-vision GmbH",
+      "email": "hello@web-vision.de",
+      "role": "Maintainer"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/web-vision/wv_deepltranslate/issues",
+    "source": "https://github.com/web-vision/wv_deepltranslate"
+  },
+  "conflict": {
+    "studiomitte/recordlist-thumbnail": "*",
+    "webvision/deepltranslate-core": "*",
+    "web-vision/deepltranslate-assets": "<1.0.0 >=2.0.0",
+    "web-vision/deepltranslate-auto-renew": "<1.0.0 >=2.0.0",
+    "web-vision/deepltranslate-mass": "<1.0.0 >=2.0.0"
+  },
+  "config": {
+    "vendor-dir": ".Build/vendor",
+    "bin-dir": ".Build/bin",
+    "optimize-autoloader": true,
+    "sort-packages": true,
+    "allow-plugins": {
+      "typo3/class-alias-loader": true,
+      "typo3/cms-composer-installers": true,
+      "helhum/typo3-console-plugin": true,
+      "php-http/discovery": true
+    }
+  },
+  "extra": {
+    "typo3/cms": {
+      "cms-package-dir": "{$vendor-dir}/typo3/cms",
+      "extension-key": "wv_deepltranslate",
+      "ignore-as-root": false,
+      "web-dir": ".Build/Web",
+      "app-dir": ".Build"
+    },
+    "branch-alias": {
+      "dev-4": "4.x.x-dev"
+    }
+  },
+  "require": {
+    "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3",
+    "ext-curl": "*",
+    "ext-json": "*",
+    "ext-pdo": "*",
+    "deeplcom/deepl-php": ">=1.6.0 <=1.8.0",
+    "typo3/cms-backend": "^11.5 || ^12.4",
+    "typo3/cms-core": "^11.5 || ^12.4",
+    "typo3/cms-extbase": "^11.5 || ^12.4",
+    "typo3/cms-fluid": "^11.5 || ^12.4",
+    "typo3/cms-install": "^11.5 || ^12.4",
+    "typo3/cms-setup": "^11.5 || ^12.4",
+    "typo3/cms-scheduler": "^11.5 || ^12.4"
+  },
+  "require-dev": {
+    "b13/container": "^2.2",
+    "friendsofphp/php-cs-fixer": "^3.41",
+    "helhum/typo3-console": "^7.1.6 || ^8.0.2",
+    "helmich/phpunit-json-assert": "^3.4.3 || ^3.5.1",
+    "helmich/typo3-typoscript-lint": "^3.1.0",
+    "nikic/php-parser": "^4.15.1",
+    "php-mock/php-mock-phpunit": "^2.6",
+    "phpstan/phpstan": "^1.10",
+    "phpunit/phpunit": "^9.6.8 || ^10.1",
+    "ramsey/uuid": "^4.2",
+    "saschaegerer/phpstan-typo3": "^1.9",
+    "sbuerk/typo3-styleguide-selector": "^11.5.5 || ^12.0.5",
+    "typo3/cms-belog": "^11.5 || ^12.4",
+    "typo3/cms-dashboard": "^11.5 || ^12.4",
+    "typo3/cms-extensionmanager": "^11.5 || ^12.4",
+    "typo3/cms-filelist": "^11.5 || ^12.4",
+    "typo3/cms-fluid-styled-content": "^11.5 || ^12.4",
+    "typo3/cms-frontend": "^11.5 || ^12.4",
+    "typo3/cms-info": "^11.5 || ^12.4",
+    "typo3/cms-lowlevel": "^11.5 || ^12.4",
+    "typo3/cms-rte-ckeditor": "^11.5 || ^12.4",
+    "typo3/cms-styleguide": "^11 || ^12",
+    "typo3/cms-tstemplate": "^11.5 || ^12.4",
+    "typo3/cms-workspaces": "^11.5 || ^12.4",
+    "typo3/testing-framework": "^7.0"
+  },
+  "suggest": {
+    "b13/container": "Just to be loaded after EXT:container",
+    "web-vision/enable-translated-content": "Adds enable translated content button to language columns in page view",
+    "web-vision/deepltranslate-assets": "Enables the translation of files in FileList Modal via deepl",
+    "typo3/cms-dashboard": "Install the package to enable the widgets from deepltranslate packages"
+  },
+  "autoload": {
+    "psr-4": {
+      "WebVision\\WvDeepltranslate\\": "Classes"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "WebVision\\WvDeepltranslate\\Tests\\": "Tests"
+    }
+  },
+  "scripts": {
+    "cs": ".Build/bin/php-cs-fixer",
+    "tl": ".Build/bin/typoscript-lint",
+    "phpstan": ".Build/bin/phpstan",
+    "phpunit": ".Build/bin/phpunit",
+    "cs:check": "@cs fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
+    "cs:fix": "@cs fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
+    "analyze:php": "@phpstan analyse --ansi --no-progress --memory-limit=768M",
+    "analyze:php:11": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon",
+    "analyze:baseline:11": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core11/phpstan-baseline.neon",
+    "analyze:php:12": "@analyze:php --configuration=Build/phpstan/Core12/phpstan.neon",
+    "analyze:baseline:12": "@analyze:php --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core12/phpstan-baseline.neon",
+    "lint:typoscript": "@tl --ansi --config=./Build/typoscript-lint/typoscript-lint.yml",
+    "lint:php": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
+    "test:php": [
+      "@test:php:unit",
+      "@test:php:functional"
+    ],
+    "test:php:unit": "@phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
+    "test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml",
+    "test:php:unit10": "@phpunit --colors=always --configuration Build/phpunit/UnitTests-10.xml",
+    "test:php:functional10": "@test:php:unit --configuration Build/phpunit/FunctionalTests-10.xml"
+  }
 }


### PR DESCRIPTION
Private addons has been developed further, and in
preparation to adopt `5.x` along with package and
extension_key renaming rised from `0.x` to `1.x`
for `4.x` version of this package. To mitigate
unsupported installation matrix, the old `0.x`
development versions are now added as conflict:

Used command(s):

```shell
cat <<< $(
  jq '.conflict."web-vision/deepltranslate-assets" = "<1.0.0 >=2.0.0"' \
  composer.json | \
  jq '.conflict."web-vision/deepltranslate-auto-renew" = "<1.0.0 >=2.0.0"' | \
  jq '.conflict."web-vision/deepltranslate-mass" = "<1.0.0 >=2.0.0"'
) > composer.json
```
