### PR TITLE
[TASK] Update `deeplcom/deepl-php`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,8 @@ jobs:
             echo EOF
           } >> "$GITHUB_ENV"
 
+      # Using minimum supported PHP version is essential to ship bundled TER vendor package
+      # compatible to the minimum version - otherwise we will have an issue.
       - name: Setup PHP 7.4 ( wv_deepltranslate 4.x )
         uses: shivammathur/setup-php@v2
         with:
@@ -79,7 +81,7 @@ jobs:
                 vendor/symfony \
                 vendor/autoload.php \
                 vendor/bin \
-              && cat <<< $(jq --indent 4 '."autoload"."psr-4" += {"DeepL\\": "vendor/deeplcom/deepl-php/src", "Http\\Discovery\\": "vendor/php-http/discovery/src"}' composer.json.orig) > composer.json.pretty \
+              && cat <<< $(jq '."autoload"."psr-4" += {"DeepL\\": "vendor/deeplcom/deepl-php/src", "Http\\Discovery\\": "vendor/php-http/discovery/src"}' composer.json.orig) > composer.json.pretty \
               && rm -rf composer.json \
               && mv composer.json.pretty composer.json \
               && rm -rf composer.json.orig

--- a/composer.json
+++ b/composer.json
@@ -62,14 +62,14 @@
     "ext-curl": "*",
     "ext-json": "*",
     "ext-pdo": "*",
-    "deeplcom/deepl-php": ">=1.6.0 <=1.8.0",
+    "deeplcom/deepl-php": "^1.11.1",
     "typo3/cms-backend": "^11.5 || ^12.4",
     "typo3/cms-core": "^11.5 || ^12.4",
     "typo3/cms-extbase": "^11.5 || ^12.4",
     "typo3/cms-fluid": "^11.5 || ^12.4",
     "typo3/cms-install": "^11.5 || ^12.4",
-    "typo3/cms-setup": "^11.5 || ^12.4",
-    "typo3/cms-scheduler": "^11.5 || ^12.4"
+    "typo3/cms-scheduler": "^11.5 || ^12.4",
+    "typo3/cms-setup": "^11.5 || ^12.4"
   },
   "require-dev": {
     "b13/container": "^2.2",


### PR DESCRIPTION
Update deepl library to include PHP 8.4 related fixes,
minimum version is required to ship compatible version
with TYPO3 Extension Repository (TER) release.

Used command(s):

```shell
BIN_COMPOSER="$( which composer )" \
&& ${BIN_COMPOSER} require --no-update \
  'deeplcom/deepl-php':'^1.11.1'
```
