### PR TITLE
[TASK] Syncronize `ext_emconf.php` and `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,9 +2,7 @@
   "name": "web-vision/wv_deepltranslate",
   "type": "typo3-cms-extension",
   "description": "This extension provides option to translate content element, and TCA record texts to DeepL supported languages using DeepL API services with TYPO3 CMS",
-  "license": [
-    "GPL-2.0-or-later"
-  ],
+  "license": ["GPL-2.0-or-later"],
   "homepage": "https://www.web-vision.de/en/automated-translations-with-typo3-and-deepl.html",
   "minimum-stability": "beta",
   "prefer-stable": true,

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -21,8 +21,13 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '4.4.3',
     'constraints' => [
         'depends' => [
-            'php' => '7.4.0-8.3.99',
             'typo3' => '11.5.0-12.4.99',
+            'backend' => '11.5.0-12.4.99',
+            'extbase' => '11.5.0-12.4.99',
+            'fluid' => '11.5.0-12.4.99',
+            'install' => '11.5.0-12.4.99',
+            'scheduler' => '11.5.0-12.4.99',
+            'setup' => '11.5.0-12.4.99',
         ],
         'conflicts' => [
             'recordlist_thumbnail' => '*',


### PR DESCRIPTION
This change syncronizes dependency defintions between
`ext_emconf.php` (classic mode / functional tests) and
`composer.json` (composer mode).

Used command(s):

```shell
BIN_COMPOSER="$( which composer )" \
&& ${BIN_COMPOSER} config license "GPL-2.0-or-later"
```
