### PR TITLE
[TASK] Minor cleanup of `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     env:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
     permissions:
       contents: write
@@ -47,7 +46,7 @@ jobs:
           fi
           {
             echo 'terReleaseNotes<<EOF'
-            echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo "https://github.com/web-vision/deepltranslate-core/tag/${{ env.version }}"
             echo EOF
           } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Use correct github repository name and
remove unused environment variable in
workflow `publish`.