### PR TITLE
[TASK] Use correct multi-version conflict constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,9 @@
   "name": "web-vision/wv_deepltranslate",
   "type": "typo3-cms-extension",
   "description": "This extension provides option to translate content element, and TCA record texts to DeepL supported languages using DeepL API services with TYPO3 CMS",
-  "license": ["GPL-2.0-or-later"],
+  "license": [
+    "GPL-2.0-or-later"
+  ],
   "homepage": "https://www.web-vision.de/en/automated-translations-with-typo3-and-deepl.html",
   "minimum-stability": "beta",
   "prefer-stable": true,
@@ -27,9 +29,9 @@
   "conflict": {
     "studiomitte/recordlist-thumbnail": "*",
     "webvision/deepltranslate-core": "*",
-    "web-vision/deepltranslate-assets": "<1.0.0 >=2.0.0",
-    "web-vision/deepltranslate-auto-renew": "<1.0.0 >=2.0.0",
-    "web-vision/deepltranslate-mass": "<1.0.0 >=2.0.0"
+    "web-vision/deepltranslate-assets": "<1.0.0 || >=2.0.0",
+    "web-vision/deepltranslate-auto-renew": "<1.0.0 || >=2.0.0",
+    "web-vision/deepltranslate-mass": "<1.0.0 || >=2.0.0"
   },
   "config": {
     "vendor-dir": ".Build/vendor",


### PR DESCRIPTION
Recently, concflict definition for private addon extensions
has been added to allow only the `1.x` range of them, sadly
a not workable constraint has been used.

Used invalid constraint:

```
<1.0.0 >=2.0.0"
```

tells composer that a given version must be lesser than
`1.0.0` and greater-or-equal than `2.0.0` at the same
time, which is not possible. The correct way would be to
rephase this to an `< 1.0.0 OR >= 2.0.0 are conflicting`
and reflected by the now set constraint:

```
<1.0.0 || >=2.0.0"
```

Used command(s):

```shell
cat <<< $(
  jq '.conflict."web-vision/deepltranslate-assets" = "<1.0.0 || >=2.0.0"' \
  composer.json | \
  jq '.conflict."web-vision/deepltranslate-auto-renew" = "<1.0.0 || >=2.0.0"' | \
  jq '.conflict."web-vision/deepltranslate-mass" = "<1.0.0 || >=2.0.0"'
) > composer.json
```
