### PR TITLE
[DOCS] Mention package renaming and 5.x upgrade hurdles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
 * [TASK] Define classic mode autoloader in `ext_emconf.php` for depending and shipped packages by @calien666 in https://github.com/web-vision/deepltranslate-core/pull/421
 * [TASK] Move glossary related documentation to `deepltranslate-glossary` by @calien666 in https://github.com/web-vision/deepltranslate-core/pull/422
 
+> [!IMPORTANT]
+> The package name and extension key has been renamed,
+> see [Documentation/Administration/Updates/Index.rst](https://docs.typo3.org/p/web-vision/deepltranslate-core/main/en-us/Administration/Updates/Index.html).
+
 ### 4.4.0
 
 * [BUGFIX] Detected current page right for pages by @Mabahe in https://github.com/web-vision/wv_deepltranslate/pull/329

--- a/Documentation/Administration/Updates/Index.rst
+++ b/Documentation/Administration/Updates/Index.rst
@@ -9,8 +9,13 @@ Updates
 Version 4.x > 5.x
 =================
 
-Starting with 5.x the composer package name and extension key has been renamed,
-which requires to uninstall previous extension first.
+Starting with 5.x the composer package name and extension key has been renamed!
+
+You need to migrate the extension settings from
+``['TYPO3_CONF_VARS']['EXTENSIONS']['wv_deepltranslate']`` to
+``['TYPO3_CONF_VARS']['EXTENSIONS']['deepltranslate_core']``.
+
+Then you will need to replace the previous package by uninstalling it first.
 
 composer-mode
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Update to 5.0 was possible, but then I had to migrate the extension settings,
which showed that the package key was changed as well.

I added a note about this into the Changelog, since this is a rather large alteration.