### PR TITLE
[!!!][TASK] Remove `DeepL Translate` fallback to `HREF` and `ISO` config

### DIFF
--- a/Build/phpstan/Core12/phpstan-baseline.neon
+++ b/Build/phpstan/Core12/phpstan-baseline.neon
@@ -51,11 +51,6 @@ parameters:
 			path: ../../../Classes/Override/LocalizationController.php
 
 		-
-			message: "#^Property WebVision\\\\Deepltranslate\\\\Core\\\\Service\\\\LanguageService\\:\\:\\$possibleLangMatches type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../../Classes/Service/LanguageService.php
-
-		-
 			message: "#^Call to method write\\(\\) on an unknown class TYPO3\\\\CMS\\\\Core\\\\Configuration\\\\SiteWriter\\.$#"
 			count: 1
 			path: ../../../Classes/Upgrades/FormalityUpgradeWizard.php

--- a/Build/phpstan/Core13/phpstan-baseline.neon
+++ b/Build/phpstan/Core13/phpstan-baseline.neon
@@ -56,11 +56,6 @@ parameters:
 			path: ../../../Classes/Override/LocalizationController.php
 
 		-
-			message: "#^Property WebVision\\\\Deepltranslate\\\\Core\\\\Service\\\\LanguageService\\:\\:\\$possibleLangMatches type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: ../../../Classes/Service/LanguageService.php
-
-		-
 			message: "#^Method WebVision\\\\Deepltranslate\\\\Core\\\\Utility\\\\DeeplBackendUtility\\:\\:buildBackendRoute\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: ../../../Classes/Utility/DeeplBackendUtility.php

--- a/Classes/Exception/LanguageIsoCodeNotFoundException.php
+++ b/Classes/Exception/LanguageIsoCodeNotFoundException.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core\Exception;
 
+/**
+ * @deprecated since v5 since no longer thrown and will be removed in v6.
+ */
 class LanguageIsoCodeNotFoundException extends \Exception
 {
 }

--- a/Classes/Hooks/AbstractTranslateHook.php
+++ b/Classes/Hooks/AbstractTranslateHook.php
@@ -14,6 +14,7 @@ use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\Deepltranslate\Core\Domain\Dto\TranslateContext;
 use WebVision\Deepltranslate\Core\Domain\Repository\PageRepository;
+use WebVision\Deepltranslate\Core\Exception\InvalidArgumentException;
 use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
 use WebVision\Deepltranslate\Core\Service\DeeplService;
@@ -72,10 +73,20 @@ abstract class AbstractTranslateHook
 
         $context->setSourceLanguageCode($sourceLanguageRecord['languageCode']);
 
-        $targetLanguageRecord = $this->languageService->getTargetLanguage($site, $targetLanguageUid);
+        try {
+            $targetLanguageRecord = $this->languageService->getTargetLanguage($site, $targetLanguageUid);
+        } catch (\Throwable $e) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'The target language is not DeepL supported. Possibly wrong Site configuration. Message: %s',
+                    $e->getMessage(),
+                ),
+                1746962367,
+                $e,
+            );
+        }
 
         $context->setTargetLanguageCode($targetLanguageRecord['languageCode']);
-
         if (
             $targetLanguageRecord['formality'] !== ''
             && $this->deeplService->hasLanguageFormalitySupport($targetLanguageRecord['languageCode'])

--- a/Classes/Service/LanguageService.php
+++ b/Classes/Service/LanguageService.php
@@ -5,26 +5,12 @@ declare(strict_types=1);
 namespace WebVision\Deepltranslate\Core\Service;
 
 use TYPO3\CMS\Core\Site\Entity\Site;
-use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
+use WebVision\Deepltranslate\Core\Exception\InvalidArgumentException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
 
 final class LanguageService
 {
     protected DeeplService $deeplService;
-
-    /**
-     * @todo TYPO3 v12 do not have hreflang & iso-639-1 directly in the raw language configurations anymore.
-     *       @link LanguageService::getTargetLanguage() for additional commets.
-     *       See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/77807
-     *            https://review.typo3.org/c/Packages/TYPO3.CMS/+/77597
-     *            https://review.typo3.org/c/Packages/TYPO3.CMS/+/77726
-     *            https://review.typo3.org/c/Packages/TYPO3.CMS/+/77814
-     */
-    protected array $possibleLangMatches = [
-        'deeplTargetLanguage',
-        'hreflang',
-        'iso-639-1',
-    ];
 
     public function __construct(
         DeeplService $deeplService
@@ -58,72 +44,44 @@ final class LanguageService
     /**
      * @return array{uid: int, title: string, language_isocode: string, languageCode: string, formality: string}
      * @throws LanguageRecordNotFoundException
-     * @throws LanguageIsoCodeNotFoundException
+     * @throws InvalidArgumentException
      */
     public function getTargetLanguage(Site $currentSite, int $languageId): array
     {
-        // @todo TYPO3 v12 changed locale API and therefore site configuration. Configured languages do no longer
-        //       directly contains values like hreflang or iso-639-1 directly. Possible workarounds would be to
-        //       operate directly on the siteLanguage objects and no longer use the raw configuration values.
-        //       See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/77807
-        //            https://review.typo3.org/c/Packages/TYPO3.CMS/+/77597
-        //            https://review.typo3.org/c/Packages/TYPO3.CMS/+/77726
-        //            https://review.typo3.org/c/Packages/TYPO3.CMS/+/77814
-        $languages = array_filter($currentSite->getConfiguration()['languages'], function ($value) use ($languageId) {
-            if (!is_array($value)) {
-                return false;
+        try {
+            $language = $currentSite->getLanguageById($languageId);
+        } catch (\Exception $e) {
+            if ($e->getCode() === 1522960188) {
+                throw new LanguageRecordNotFoundException(
+                    sprintf('Language "%d" in site "%s" not found.', $languageId, $currentSite->getIdentifier()),
+                    1746959505,
+                    $e,
+                );
             }
-
-            if ((int)$value['languageId'] === $languageId) {
-                return true;
-            }
-
-            return false;
-        });
-
-        if (count($languages) === 0) {
-            throw new LanguageRecordNotFoundException(
-                sprintf(
-                    'Language "%d" not found in SiteConfig "%s"',
-                    $languageId,
-                    (string)($currentSite->getConfiguration()['websiteTitle'] ?? '')
-                ),
-                1676824459
+            throw $e;
+        }
+        $configuration = $language->toArray();
+        $deeplTargetLanguage = $configuration['deeplTargetLanguage'] ?? null;
+        if ($deeplTargetLanguage === null || $deeplTargetLanguage === '') {
+            throw new InvalidArgumentException(
+                sprintf('Missing deeplTargetLanguage or Language "%d" in site "%s"', $languageId, $currentSite->getIdentifier()),
+                1746973481,
             );
         }
-        $language = reset($languages);
-        $languageCode = null;
 
-        foreach ($this->possibleLangMatches as $possibleLangMatch) {
-            if (!array_key_exists($possibleLangMatch, $language)) {
-                continue;
-            }
-
-            if (!$this->deeplService->isTargetLanguageSupported(strtoupper($language[$possibleLangMatch]))) {
-                continue;
-            }
-
-            $languageCode = strtoupper($language[$possibleLangMatch]);
-            break;
-        }
-
-        if ($languageCode === null) {
-            throw new LanguageIsoCodeNotFoundException(
-                sprintf(
-                    'No API supported target found for language "%s" in site "%s"',
-                    $language['title'],
-                    (string)($currentSite->getConfiguration()['websiteTitle'] ?? '')
-                ),
-                1676741837
+        if (!$this->deeplService->isTargetLanguageSupported($deeplTargetLanguage)) {
+            throw new InvalidArgumentException(
+                sprintf('The given language key "%s" is not supported by DeepL. Possibly wrong Site configuration.', $deeplTargetLanguage),
+                1746959745,
             );
         }
 
         return [
-            'uid' => $language['languageId'] ?? 0,
-            'title' => $language['title'],
-            'language_isocode' => $languageCode,
-            'languageCode' => $languageCode,
-            'formality' => $language['deeplFormality'] ?? '',
+            'uid' => $language->getLanguageId(),
+            'title' => $language->getTitle(),
+            'language_isocode' => $deeplTargetLanguage,
+            'languageCode' => $deeplTargetLanguage,
+            'formality' => $configuration['deeplFormality'] ?? '',
         ];
     }
 }

--- a/Classes/Utility/DeeplBackendUtility.php
+++ b/Classes/Utility/DeeplBackendUtility.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use WebVision\Deepltranslate\Core\Configuration;
 use WebVision\Deepltranslate\Core\Domain\Dto\CurrentPage;
-use WebVision\Deepltranslate\Core\Exception\LanguageIsoCodeNotFoundException;
+use WebVision\Deepltranslate\Core\Exception\InvalidArgumentException;
 use WebVision\Deepltranslate\Core\Exception\LanguageRecordNotFoundException;
 use WebVision\Deepltranslate\Core\Service\IconOverlayGenerator;
 use WebVision\Deepltranslate\Core\Service\LanguageService;
@@ -131,13 +131,11 @@ final class DeeplBackendUtility
             /** @var LanguageService $languageService */
             $languageService = GeneralUtility::makeInstance(LanguageService::class);
             $site = GeneralUtility::makeInstance(SiteFinder::class)->getSiteByPageId($pageId);
-
             $languageService->getSourceLanguage($site);
             $languageService->getTargetLanguage($site, $languageId);
-        } catch (LanguageIsoCodeNotFoundException|LanguageRecordNotFoundException|SiteNotFoundException $e) {
+        } catch (LanguageRecordNotFoundException|SiteNotFoundException|InvalidArgumentException) {
             return false;
         }
-
         return true;
     }
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,31 @@
+# Upgrade 5.x
+
+## X.Y.Z
+
+### (BREAKING): Removed language fallback using SiteConfig ISO and HREF
+
+DeeplTranslate only supports a narrowed down list of selected languages, which
+is only a subset of TYPO3 supported languages and the reason why a dedicated
+option `DeeplTranslate Language` is provided on the SiteConfig language level.
+
+As a left over from the original `Proof-of-Concept` phase and the first version
+iteration a fallback to `HREF` and `ISO Locale` has been in place trying to get
+some kind of fallback. That turned out not to be that reliable and becomes more
+unreliable and invalid with planned upcoming features.
+
+Even with the fallback in place it has been recommended to specify the deepl
+translate language manually for a long time and the fallback is now removed
+in favour of explicit, manual configuration.
+
+> [!IMPORTANT]
+> This is technically breaking and SiteConfiguration needs to be checked and
+> the language set manually to mitigate this issue. This can be done already
+> since quite a lot version.
+
+## 5.0.3
+
+## 5.0.2
+
+## 5.0.1
+
+## 5.0.0


### PR DESCRIPTION
DeeplTranslate only supports a narrowed down list of selected
languages, which is only a subset of TYPO3 supported languages
and the reason why a dedicated option `DeeplTranslate Language`
is provided on the SiteConfig language level.

As a left over from the original `Proof-of-Concept` phase and
the first version iteration a fallback to SiteConfig language
`HREF` and `ISO Locale` has been in place trying to get some
kind of fallback. That turned out not to be that reliable and
becomes more unreliable and invalid with planned upcoming
features.

Even with the fallback in place it has been recommended to
specify the deepl translate language manually for a long time
and the fallback is now removed in favour of explicit, manual
configuration.

> [!IMPORTANT]
> This is technically breaking and SiteConfiguration needs to
> be checked and the language set manually to mitigate this issue.
> This can be done already since quite a lot version.