### PR TITLE
[TASK] Make `Configuration` default for `ConfigurationInterface`

### DIFF
--- a/Classes/Configuration.php
+++ b/Classes/Configuration.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace WebVision\Deepltranslate\Core;
 
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
 use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-final class Configuration implements ConfigurationInterface, SingletonInterface
+#[AsAlias(id: ConfigurationInterface::class, public: true)]
+final class Configuration implements ConfigurationInterface
 {
     private string $apiKey = '';
 


### PR DESCRIPTION
It's a good practice to define interfaces and provide a default
implementation making xclass strategies, stubbing or mocking in
tests and similar techniques easier. Default implementation, if
provided, should be configured in the DI configuration as alias
for the interface, not done for the `ConfigurationInterface` on
the default implementation `Configuration`.

TYPO3 `SingeltonInterface` stems from old times before DI has
been introduced to TYPO3 and has been used to mark classes as
`shared` (only instanciated onces) within `GeneralUtilitiy`,
something is the default behaviour for services in DI as long
as not configured otherwise. Having `ConfigurationInterface`
and `Configuration` DI aware makes the `SingeltonInterface`
obsolete.

Services implementing `SingletonInterface` are automatically
configured as `public: true` by a TYPO3 DI compiler pass and
needs to be set manually when removing the interface from a
service.

This change ...

* Remove `SingletonInterface` from `Configurtion` in favour
  of default `shared: true` of the DI.
* Use Symfony `AsAlias` php attribute on `Configuration` to
  mark it as the default `ConfigurationInterface` service,
  addtional setting the service as `public: true` to allow
  retrieval using `GeneralUtility::makeInstance()`.

That prepares towards retrieving services by DI either as
constructor or `inject*` methods in the future.
