### PR TITLE
[BUGFIX] Mitigate splitted DataHandler hook method of `EXT:container`

### DIFF
--- a/Classes/Override/CommandMapPostProcessingHook.php
+++ b/Classes/Override/CommandMapPostProcessingHook.php
@@ -26,7 +26,29 @@ class CommandMapPostProcessingHook extends \B13\Container\Hooks\Datahandler\Comm
         }
         $id = (int)$id;
         if ($table === 'tt_content' && $command === 'deepltranslate') {
-            $this->localizeOrCopyToLanguage($id, (int)$value, $command, $dataHandler);
+            // b13/container reworked their DataHandler hook implementation and splitted the method into
+            // dedicated methods, which needs to be handled here to allow multiple b13/container versions.
+            // See:
+            // - https://github.com/b13/container/issues/609
+            // - https://github.com/b13/container/pull/617
+            if (method_exists($this, 'localizeOrCopyToLanguage')) {
+                $this->localizeOrCopyToLanguage($id, (int)$value, $command, $dataHandler);
+            } elseif (method_exists($this, 'localizeChildren')) {
+                $this->localizeChildren($id, (int)$value, $command, $dataHandler);
+            } else {
+                throw new \RuntimeException(
+                    sprintf(
+                        implode('', [
+                            'Extension "%s" changed their internal DataHandler hook implementation "%s" again. Please ',
+                            'open an issue on "%s" and report the issue so it can be adopted.',
+                        ]),
+                        'b13/container',
+                        \B13\Container\Hooks\Datahandler\CommandMapPostProcessingHook::class,
+                        'https://github.com/web-vision/deepltranslate-core/issues',
+                    ),
+                    1748860059,
+                );
+            }
         } else {
             parent::processCmdmap_postProcess($command, $table, $id, $value, $dataHandler, $pasteUpdate, $pasteDatamap);
         }


### PR DESCRIPTION
The `b13/container` extension (`EXT:container` ) implements a custom
DataHandler hook to process data in the required manner and recently
splitted the method `localizeOrCopyToLanguage()` into two dedicated
methods for the `CommandMapPostProcessingHook` [2] to fix an issue [1].

`EXT:deepltranslate_core` needs to override that hook in case that
extension is installed to ensure both extension to work and broke
due to that change.

This change mitigates this by verify the existance of the methods
now and call the existing once and throws an exception if if will
be renamed again in the future.

[1] https://github.com/b13/container/issues/609
[2] https://github.com/b13/container/pull/617
