### PR TITLE
[TASK] Switch to indirect `web-vision/deeplcom-deepl-php` client extension

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,6 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     env:
-      TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
     permissions:
       contents: write
@@ -63,32 +62,6 @@ jobs:
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2
 
-      - name: Prepare vendor folder and autoload configuration for TER upload
-        shell: bash
-        run: |
-          rm -rf vendor composer.lock composer.json.orig composer.json.pretty \
-            && mv composer.json composer.json.orig \
-              && composer init -n \
-                --type=project \
-                --license='GPL-2.0-or-later' \
-                --name=release/draft \
-                --description empty \
-                --author='release' \
-              && composer config allow-plugins.php-http/discovery true \
-              && composer require "deeplcom/deepl-php":"$( cat composer.json.orig | jq -r '.require."deeplcom/deepl-php"' )" \
-              && rm -rf composer.lock \
-                vendor/composer \
-                vendor/nyholm \
-                vendor/php-http/multipart-stream-builder \
-                vendor/psr \
-                vendor/symfony \
-                vendor/autoload.php \
-                vendor/bin \
-              && cat <<< $(jq --indent 4 '."autoload"."psr-4" += {"DeepL\\": "vendor/deeplcom/deepl-php/src", "Http\\Discovery\\": "vendor/php-http/discovery/src"}' composer.json.orig) > composer.json.pretty \
-              && rm -rf composer.json \
-              && mv composer.json.pretty composer.json \
-              && rm -rf composer.json.orig
-
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
 
@@ -103,7 +76,9 @@ jobs:
       # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
       # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
       - name: Create release and upload artifacts in the same step
-        uses: softprops/action-gh-release@v2
+        # @todo Revert to release version when https://github.com/softprops/action-gh-release/issues/628 is fixed.
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
+        # uses: softprops/action-gh-release@v2
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
           name: "[RELEASE] ${{ env.version }}"
@@ -114,13 +89,7 @@ jobs:
             LICENSE
           fail_on_unmatched_files: true
 
-      # @todo Currently an issue exists with the TYPO3 Extension Repository (TER) tailor based uploads, which seems to
-      #       be WAF related and the T3O TER Team working on. Allow this step to fail (continue on error) for now until
-      #       issues has been sorted out.
-      #       https://github.com/TYPO3/tailor/issues/82
       - name: Publish to TER
-        # @todo Remove `continue-on-error` after upload with tailor has been fixed.
-        continue-on-error: true
         run: |
           php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.terReleaseNotes }}" ${{ env.version }} \
             --artefact=tailor-version-artefact/${{ env.DETECTED_EXTENSION_KEY }}_${{ env.version }}.zip

--- a/Tests/Functional/AbstractDeepLTestCase.php
+++ b/Tests/Functional/AbstractDeepLTestCase.php
@@ -111,6 +111,7 @@ abstract class AbstractDeepLTestCase extends FunctionalTestCase
      */
     protected array $testExtensionsToLoad = [
         'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
         'web-vision/deepltranslate-core',
         __DIR__ . '/Fixtures/Extensions/test_services_override',
     ];

--- a/Tests/Functional/Container/ContentElementsInContainerTest.php
+++ b/Tests/Functional/Container/ContentElementsInContainerTest.php
@@ -22,6 +22,7 @@ final class ContentElementsInContainerTest extends AbstractDeepLTestCase
     protected array $testExtensionsToLoad = [
         'b13/container',
         'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
         'web-vision/deepltranslate-core',
         __DIR__ . '/../Fixtures/Extensions/test_services_override',
         __DIR__ . '/Fixtures/Extensions/test_container',

--- a/Tests/Functional/Hooks/TranslationWithModifiedTcaConfigurationTest.php
+++ b/Tests/Functional/Hooks/TranslationWithModifiedTcaConfigurationTest.php
@@ -67,6 +67,7 @@ final class TranslationWithModifiedTcaConfigurationTest extends AbstractDeepLTes
      */
     protected array $testExtensionsToLoad = [
         'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
         'web-vision/deepltranslate-core',
         __DIR__ . '/../Fixtures/Extensions/test_services_override',
         __DIR__ . '/Fixtures/Extensions/test_tca_override',

--- a/Tests/Functional/Regression/LocalizationInlineRegressionTest.php
+++ b/Tests/Functional/Regression/LocalizationInlineRegressionTest.php
@@ -19,6 +19,7 @@ final class LocalizationInlineRegressionTest extends AbstractDeepLTestCase
      */
     protected array $testExtensionsToLoad = [
         'web-vision/deepl-base',
+        'web-vision/deeplcom-deepl-php',
         'web-vision/deepltranslate-core',
         __DIR__ . '/../Fixtures/Extensions/test_services_override',
     ];

--- a/composer.json
+++ b/composer.json
@@ -76,13 +76,13 @@
 		"ext-curl": "*",
 		"ext-json": "*",
 		"ext-pdo": "*",
-		"deeplcom/deepl-php": "^1.10.1",
 		"typo3/cms-backend": "^12.4.2 || ^13.4",
 		"typo3/cms-core": "^12.4.2 || ^13.4",
 		"typo3/cms-extbase": "^12.4.2 || ^13.4",
 		"typo3/cms-fluid": "^12.4.2 || ^13.4",
 		"typo3/cms-setup": "^12.4.2 || ^13.4",
-		"web-vision/deepl-base": "1.*.*@dev"
+		"web-vision/deepl-base": "1.*.*@dev",
+		"web-vision/deeplcom-deepl-php": "^1.12.0"
 	},
 	"require-dev": {
 		"b13/container": "^2.3.6 || ^3.1.1",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -18,6 +18,7 @@ $EM_CONF[$_EXTKEY] = [
             'fluid' => '12.4.0-13.4.99',
             'setup' => '12.4.0-13.4.99',
             'deepl_base' => '1.0.0-1.99.99',
+            'deeplcom_deeplphp' => '1.12.0-1.99.99',
         ],
         'conflicts' => [
             'recordlist_thumbnail' => '*',
@@ -31,16 +32,6 @@ $EM_CONF[$_EXTKEY] = [
             'deepltranslate_assets' => '*',
             'deepltranslate_glossary' => '*',
             'gridelements' => '*',
-        ],
-    ],
-    // @todo Autoload section in `ext_emconf.php` should not be needed anymore since TYPO3 v12, and in first test it
-    //       showed to work without it. This should be verified debugging TYPO3 core to be really sure about that and
-    //       making additional tests. Scheduled to be removed if removal can be considered safe.
-    'autoload' => [
-        'psr-4' => [
-            'WebVision\\Deepltranslate\\Core\\' => 'Classes',
-            'DeepL\\' => 'vendor/deeplcom/deepl-php/src',
-            'Http\\Discovery\\' => 'vendor/php-http/discovery/src',
         ],
     ],
 ];


### PR DESCRIPTION
Direct PHP API Client package dependency is now replaced with
the indirect dependency using `web-vision/deeplcom-deepl-php`
as shared extension allowing to have more then one extension
released in TER requiring that dependency and bundling client
package for TER uploade is removed along the way.

Used command(s):

```shell
BIN_COMPOSER="$(which composer)" && \
${BIN_COMPOSER} remove --no-update \
  'deeplcom/deepl-php' && \
${BIN_COMPOSER} require --no-update \
  'web-vision/deeplcom-deepl-php':'^1.12.0'
```
