### PR TITLE
[TASK] Restore `ext_emconf.php` autoload namespace registration

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -34,4 +34,9 @@ $EM_CONF[$_EXTKEY] = [
             'gridelements' => '*',
         ],
     ],
+    'autoload' => [
+        'psr-4' => [
+            'WebVision\\Deepltranslate\\Core\\' => 'Classes',
+        ],
+    ],
 ];


### PR DESCRIPTION
Since TYPO3 v12 it should be obsolete to state in the
`ext_emconf.php` file when extension composer.json has
such a section and should not be merged.

That has not been verified to the very end and we
restore the autoload section in `ext_emconf.php`
for now.
