### PR TITLE
[TASK] Raise `web-vision/deepl-base` to include latest bugfix

### DIFF
--- a/Classes/Event/Listener/ApplyLocalizationModesEventListener.php
+++ b/Classes/Event/Listener/ApplyLocalizationModesEventListener.php
@@ -27,7 +27,7 @@ final class ApplyLocalizationModesEventListener
                 description: $event->getLanguageService()->sL('LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:localize.educate.deepltranslate'),
                 icon: ($majorVersion === 13 ? 'actions-localize-deepl-13' : 'actions-localize-deepl'),
                 before: [],
-                after: ['translate', 'copy'],
+                after: [LocalizationController::ACTION_LOCALIZE, LocalizationController::ACTION_COPY],
             );
         }
         if ($this->allowDeeplTranslateAuto($event)) {
@@ -38,7 +38,7 @@ final class ApplyLocalizationModesEventListener
                 description: $event->getLanguageService()->sL('LLL:EXT:deepltranslate_core/Resources/Private/Language/locallang.xlf:localize.educate.deepltranslateAuto'),
                 icon: ($majorVersion === 13 ? 'actions-localize-deepl-13' : 'actions-localize-deepl'),
                 before: [],
-                after: ['translate', 'copy', 'deepltranslate'],
+                after: [LocalizationController::ACTION_LOCALIZE, LocalizationController::ACTION_COPY],
             );
         }
         if ($modes !== []) {

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
 		"typo3/cms-extbase": "^12.4.2 || ^13.4",
 		"typo3/cms-fluid": "^12.4.2 || ^13.4",
 		"typo3/cms-setup": "^12.4.2 || ^13.4",
-		"web-vision/deepl-base": "1.*.*@dev",
+		"web-vision/deepl-base": "^1.0.2@dev",
 		"web-vision/deeplcom-deepl-php": "^1.12.1"
 	},
 	"require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -17,7 +17,7 @@ $EM_CONF[$_EXTKEY] = [
             'extbase' => '12.4.0-13.4.99',
             'fluid' => '12.4.0-13.4.99',
             'setup' => '12.4.0-13.4.99',
-            'deepl_base' => '1.0.0-1.99.99',
+            'deepl_base' => '1.0.2-1.99.99',
             'deeplcom_deeplphp' => '1.12.1-1.99.99',
         ],
         'conflicts' => [


### PR DESCRIPTION
- **[TASK] Adopt changed core translation mode identifiers**
  The identifier used for core translation modes in the
  dependency package `web-vision/deepl-base` has been
  fixed with [1] and released as `1.0.2` [2] to restore
  working TYPO3 core localization and copy behaviour.
  
  This change uses the same identifier with the class
  constants from the LocalizationController for own
  custom localization modes as `after` definition to
  keep the same sorting alive we strives for and acts
  as preparation for rising the dependency to `1.0.2`
  as minimal version to ensure overall working state.
  
  [1] https://github.com/web-vision/deepl-base/pull/13
  [2] https://github.com/web-vision/deepl-base/releases/tag/1.0.2
  

- **[TASK] Raise `web-vision/deepl-base` to `^1.0.2`**
  External dependency package `web-vision/deepl-base`
  released new version `1.0.2` including a required
  bugfix changing the used identifier for provided
  TYPO3 core localization modes and required adoption
  has been done with previous change.
  
  This change rises the required minimum version for
  that dependency to ensure a working state and avoid
  conflict matrix constellation not working properly.
  
  `ext_emconf.php` dependency is also updated to keep the
  dependency chain in sync with `composer.json`.
  
  Used command(s):
  
  ```shell
  BIN_COMPOSER="$( which composer )" ; \
    ${BIN_COMPOSER} require 'web-vision/deepl-base':'^1.0.2@dev'
  ```
  