### PR TITLE
[BUGFIX] Rephrase formality language label

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -96,7 +96,7 @@
 				<target>Förmlichere Sprache bevorzugen, Fallback-Standard</target>
 			</trans-unit>
 			<trans-unit id="site_configuration.deepl.field.formality.items.prefer_less">
-				<source>Prefer informal language, fallback default</source>
+				<source>Prefer more informal language, fallback default</source>
 				<target>Informelle Sprache bevorzugen, Fallback-Standard</target>
 			</trans-unit>
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -73,10 +73,10 @@
 				<source>More informal language</source>
 			</trans-unit>
 			<trans-unit id="site_configuration.deepl.field.formality.items.prefer_more">
-				<source>Prefer more language, fallback default</source>
+				<source>Prefer more formal language, fallback default</source>
 			</trans-unit>
 			<trans-unit id="site_configuration.deepl.field.formality.items.prefer_less">
-				<source>Prefer informal language, fallback default</source>
+				<source>Prefer more informal language, fallback default</source>
 			</trans-unit>
 
 			<trans-unit id="usages.toolbar-label">


### PR DESCRIPTION
nobrainer: “Prefer more langauge”? Should mean „Prefer more formal langauge“.
