### PR TITLE
[TASK] Pad the markdown tables to equal width

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,11 +12,11 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version        | Supported           |
-| -------------- | ------------------- |
-| 6.x            | :white_check_mark:  |
-| 5.x            | :white_check_mark:  |
-| < 5.0          | :x:                 |
+| Version | Supported          |
+| ------- | ------------------ |
+| 6.x     | :white_check_mark: |
+| 5.x     | :white_check_mark: |
+| < 5.0   | :x:                |
 
 Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
 
@@ -31,10 +31,10 @@ open a public GitHub/GitLab issue.
 
 ### What to expect
 
-| Step                         | Timeframe                         |
-| ----------------------------- | ---------------------------------- |
-| Acknowledgement of your report | within 1 business day (typically much faster) |
-| Status updates                | at least every 7 days until resolved |
+| Step                                | Timeframe                                                              |
+| ----------------------------------- | ---------------------------------------------------------------------- |
+| Acknowledgement of your report      | within 1 business day (typically much faster)                          |
+| Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
 
 We coordinate the disclosure timeline with the reporter and aim for a


### PR DESCRIPTION
Formatting only — no wording, version or date changes.

Pads every markdown table to equal column widths. The `What to expect` table came
unpadded from the shared template, and the supported-versions table was padded to its
own fixed widths rather than to its content.

This matters beyond appearance: `fgtclb/academic-extensions` lints markdown and
rejected the unpadded form with

    SECURITY.md:37: table rows are not padded to equal width

Normalising every table here keeps these files byte-identical to what the generator
produces, so a future regeneration shows no diff.
