### PR TITLE
[TASK] Add CRA conformity documents

### DIFF
--- a/EU-Declaration-of-Conformity.md
+++ b/EU-Declaration-of-Conformity.md
@@ -1,0 +1,72 @@
+# EU Declaration of Conformity
+
+**Product:** DeepL Translate (CORE)
+**Reference:** DoC-deepltranslate_core-6.1.0
+
+## 1. Product identification
+
+- **Product name:** DeepL Translate (CORE)
+- **Type:** TYPO3 Extension
+- **Extension key / package:** deepltranslate_core (web-vision/deepltranslate-core)
+- **Version:** 6.1.0 (initial issuance of this declaration)
+- **Valid for:** version 6.1.0 and subsequent releases, until superseded by a new declaration issued for a later substantial modification (Art. 3(30) CRA)
+- **Distribution channels:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/deepltranslate_core; Packagist — https://packagist.org/packages/web-vision/deepltranslate-core
+
+## 2. Manufacturer
+
+web-vision GmbH
+An der Eickesmühle 38
+41238 Mönchengladbach
+Germany
+
+## 3. Statement of sole responsibility
+
+This EU declaration of conformity is issued under the sole responsibility
+of the manufacturer, web-vision GmbH.
+
+## 4. Object of the declaration
+
+DeepL Translate (CORE), version 6.1.0, as distributed via the TYPO3
+Extension Repository (TER) and Packagist.
+
+## 5. Statement of conformity
+
+The object of the declaration described above is in conformity with
+Regulation (EU) 2024/2847 (Cyber Resilience Act). No other Union
+harmonisation legislation is applicable.
+
+## 6. Standards, specifications, certification
+
+No harmonised standards applied; conformity assessed under Module A
+(internal control), see Section 7.
+
+## 7. Conformity assessment procedure
+
+- **Risk class (see CRA-Risikoklassen.md):** Standard
+- **Conformity assessment module (see Annex VIII CRA):** Module A – internal control
+- **Notified body name and number:** N/A — self-assessed under Module A, no notified body involved
+- **Certificate identification:** N/A — see above
+
+## 8. Signature
+
+Signed for and on behalf of: web-vision GmbH
+
+- **Place and date of issue:** Mönchengladbach, 27 August 2026
+- **Name, function:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Signature:** Stefan Bürk
+
+---
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type DeepL Translate (CORE) is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.web-vision.de/conformity/web-vision/deepltranslate-core/6.1.0/en/
+
+## References
+
+- TEMPLATE-EU-Declaration-of-Conformity.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/EU-Konformitaetserklaerung.md
+++ b/EU-Konformitaetserklaerung.md
@@ -1,0 +1,72 @@
+# EU-Konformitätserklärung
+
+**Produkt:** DeepL Translate (CORE)
+**Referenz:** DoC-deepltranslate_core-6.1.0
+
+## 1. Produktidentifikation
+
+- **Produktname:** DeepL Translate (CORE)
+- **Typ:** TYPO3-Extension
+- **Extension Key / Package:** deepltranslate_core (web-vision/deepltranslate-core)
+- **Version:** 6.1.0 (Erstausstellung dieser Erklärung)
+- **Gültig für:** Version 6.1.0 und nachfolgende Releases, bis eine neue Erklärung wegen einer späteren wesentlichen Änderung (Art. 3 Nr. 30 CRA) ausgestellt wird
+- **Vertriebskanäle:** TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/deepltranslate_core; Packagist — https://packagist.org/packages/web-vision/deepltranslate-core
+
+## 2. Hersteller
+
+web-vision GmbH
+An der Eickesmühle 38
+41238 Mönchengladbach
+Deutschland
+
+## 3. Erklärung der alleinigen Verantwortung
+
+Die alleinige Verantwortung für die Ausstellung dieser
+EU-Konformitätserklärung trägt der Hersteller, web-vision GmbH.
+
+## 4. Gegenstand der Erklärung
+
+DeepL Translate (CORE), Version 6.1.0, vertrieben über das TYPO3
+Extension Repository (TER) und Packagist.
+
+## 5. Konformitätserklärung
+
+Der oben beschriebene Gegenstand der Erklärung erfüllt die Vorgaben der
+Verordnung (EU) 2024/2847 (Cyber Resilience Act). Weitere
+Harmonisierungsrechtsvorschriften der Union sind nicht anwendbar.
+
+## 6. Normen, Spezifikationen, Zertifizierung
+
+Keine harmonisierten Normen angewandt; Konformität nach Modul A (interne
+Kontrolle) bewertet, siehe Abschnitt 7.
+
+## 7. Konformitätsbewertungsverfahren
+
+- **Risikoklasse (siehe CRA-Risikoklassen.md):** Standard
+- **Konformitätsbewertungsmodul (siehe Anhang VIII CRA):** Modul A – interne Kontrolle
+- **Name und Nummer der notifizierten Stelle:** Entfällt — Selbstbewertung nach Modul A, keine notifizierte Stelle beteiligt
+- **Kennnummer des Zertifikats:** Entfällt — siehe oben
+
+## 8. Unterschrift
+
+Unterzeichnet für und im Namen von: web-vision GmbH
+
+- **Ort und Datum der Ausstellung:** Mönchengladbach, 27.08.2026
+- **Name, Funktion:** Stefan Bürk, CISO, i.A. der Geschäftsführung (VOLLMACHT-CISO-2026-01)
+- **Unterschrift:** Stefan Bürk
+
+---
+
+## Vereinfachte EU-Konformitätserklärung (Anhang VI)
+
+> Hiermit erklärt die web-vision GmbH, dass das Produkt mit digitalen
+> Elementen des Typs DeepL Translate (CORE) der Verordnung (EU) 2024/2847 entspricht.
+>
+> Der vollständige Text der EU-Konformitätserklärung ist unter der
+> folgenden Internetadresse verfügbar:
+> https://security.web-vision.de/conformity/web-vision/deepltranslate-core/6.1.0/de/
+
+## Referenzen
+
+- TEMPLATE-EU-Konformitaetserklaerung.md
+- Vollmacht-Konformitaetserklaerung.md (VOLLMACHT-CISO-2026-01)

--- a/README.md
+++ b/README.md
@@ -202,3 +202,35 @@ echo '>> Create release based on configuration' ; \
   gh pr merge -rd --admin && \
   git remote prune origin
 ```
+
+## Supported Versions
+
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 6.x     | :white_check_mark: | 2029-06-30     |
+| 5.x     | :white_check_mark: | 2027-12-31     |
+| < 5.0   | :x:                | support ended  |
+
+## Security
+
+Found a vulnerability? Please report it privately via our
+[security report form](https://security.web-vision.de) — **do not** open a public issue.
+See [SECURITY.md](SECURITY.md) for the full vulnerability disclosure policy,
+including what to expect and our safe harbor statement.
+
+## Simplified EU Declaration of Conformity (Annex VI)
+
+> Hereby, web-vision GmbH declares that the product with digital elements
+> type DeepL Translate (CORE) is in compliance with Regulation (EU) 2024/2847.
+>
+> The full text of the EU declaration of conformity is available at the
+> following internet address:
+> https://security.web-vision.de/conformity/web-vision/deepltranslate-core/6.1.0/en/
+
+The full declarations are also included in this repository:
+[English](EU-Declaration-of-Conformity.md) ·
+[Deutsch](EU-Konformitaetserklaerung.md).
+
+## License
+
+This extension is released under the [GPL-2.0-or-later](LICENSE) license.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,13 +12,11 @@ Security updates are provided for the following versions. Versions marked
 unsupported no longer receive security fixes; please upgrade before
 reporting an issue against them.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 6.x     | :white_check_mark: |
-| 5.x     | :white_check_mark: |
-| < 5.0   | :x:                |
-
-Planned end of support for this product: **30 June 2029 (end of regular TYPO3 14 LTS support)**.
+| Version | Supported          | End of Support |
+|---------|--------------------|----------------|
+| 6.x     | :white_check_mark: | 2029-06-30     |
+| 5.x     | :white_check_mark: | 2027-12-31     |
+| < 5.0   | :x:                | support ended  |
 
 ## Reporting a Vulnerability
 
@@ -32,7 +30,7 @@ open a public GitHub/GitLab issue.
 ### What to expect
 
 | Step                                | Timeframe                                                              |
-| ----------------------------------- | ---------------------------------------------------------------------- |
+|-------------------------------------|------------------------------------------------------------------------|
 | Acknowledgement of your report      | within 1 business day (typically much faster)                          |
 | Status updates                      | at least every 7 days until resolved                                   |
 | Fix / mitigation, based on severity | Critical/High: as fast as possible; Medium/Low: next scheduled release |
@@ -57,8 +55,11 @@ researchers who:
 
 ## Scope
 
-In scope: the source code, released versions, and official distribution
-channels of "web-vision/deepltranslate-core" (e.g. TER / Packagist).
+In scope: the source code, released versions, and the official distribution
+channels of "web-vision/deepltranslate-core":
+
+- TYPO3 Extension Repository (TER) — https://extensions.typo3.org/extension/deepltranslate_core
+- Packagist — https://packagist.org/packages/web-vision/deepltranslate-core
 
 Out of scope: third-party dependencies (please report those upstream, but
 feel free to let us know so we can track and update them), and


### PR DESCRIPTION
Adds the CRA documents for this branch, taken verbatim from the
`wv-people/cra` repository (`main`, `18505c5`), where they were reviewed and
approved. Nothing here is authored independently of that repository — it is the
single source of truth for these files.

## What this branch gets

| Package | Version | Highest TYPO3 | End of support |
|---|---|---|---|
| `web-vision/deepltranslate-core` | 6.1.0 | TYPO3 14 | 2029-06-30 |

Files added or updated at the repository root:

- `SECURITY.md` — replaces the previous version. `Supported Versions` is now a
  table carrying an end-of-support date per major version, derived from the
  community-support end of the highest TYPO3 version that major supports.
- `EU-Declaration-of-Conformity.md` and `EU-Konformitaetserklaerung.md` — the
  full EU declaration of conformity under Regulation (EU) 2024/2847, English
  and German, signed under `VOLLMACHT-CISO-2026-01`.
- `README.md` — gains four sections at the end: `Supported Versions`, `Security`,
  `Simplified EU Declaration of Conformity (Annex VI)` and `License`. Existing
  content is untouched; a `License` section that already existed is kept as it is.

## Why the Annex VI section in the README

CRA Annex VI requires the simplified declaration to state the exact internet
address of the full declaration. TER and Packagist build their product pages
from `README.md`, not from `SECURITY.md`, so the README is the only place that
reaches those distribution channels.

## Scope rule

A major version is covered when the highest TYPO3 version it supports is still
in regular community support — TYPO3 13 until 2027-12-31, TYPO3 14 until
2029-06-30. TYPO3 12 went ELTS on 2026-04-30, so majors capped at 12 or below
are out of scope and get no declaration.

---

## Scope: this is phase 1

The CRA repository's `docs/TEMPLATE-README-EN.md` defines the full set of
user-information sections required by **Annex II** of Regulation (EU) 2024/2847,
and explicitly says not to drop a section merely because it is short. This pull
request deliberately covers only the part that can be generated correctly and
identically for every extension:

| Annex II | Section | Status |
|---|---|---|
| pt 2 | Reporting a vulnerability | in this PR |
| pt 6 | EU Declaration of Conformity | in this PR |
| pt 7 | Security support & update policy | in this PR |
| — | License | in this PR |
| pt 1 | Manufacturer (name, postal address, contact) | **open** |
| pt 4 (2) | Security environment & security properties | **open** |
| pt 5 | Known risks & foreseeable misuse | **open** |
| pt 8.1 | Installation & secure initial setup | **open** |
| pt 8.2 | Configuration changes & data security | **open** |
| pt 8.3 | Installing security updates | **open** |
| pt 8.4 | Uninstallation & data removal | **open** |
| pt 8.5 | Automatic security updates | **open** |
| pt 8.6 | Notes for integrators | **open** |
| pt 9 | Software Bill of Materials (SBOM) | **open** |

The open sections need per-product wording and are tracked in a separate issue
on this repository. Merging this PR does **not** make the product Annex II
complete — it establishes the reporting channel, the declaration link and the
supported-version statement, which are the parts with a hard external
dependency (the published declaration under `/conformity/`).